### PR TITLE
Chore: color with opacity utils

### DIFF
--- a/src/assets/styles/colors.js
+++ b/src/assets/styles/colors.js
@@ -5,11 +5,31 @@ const colors = {
   surface: '#F4F1F1',
   action: '#0C6986',
   error: '#C04545',
-  'on-primary': '#0C6986',
+  'on-primary': {
+    high: '#0C6986',
+    medium: 'rgba(12, 105, 134, 0.54)',
+    disabled: 'rgba(12, 105, 134, 0.38)',
+    divider: 'rgba(12, 105, 134, 0.12)'
+  },
   'on-primary-white': '#FFFFFF',
-  'on-secondary': '#0C6986',
-  'on-background': '#000000',
-  'on-surface': '#000000'
+  'on-secondary': {
+    high: '#0C6986',
+    medium: 'rgba(12, 105, 134, 0.54)',
+    disabled: 'rgba(12, 105, 134, 0.38)',
+    divider: 'rgba(12, 105, 134, 0.12)'
+  },
+  'on-background': {
+    high: '#000000',
+    medium: 'rgba(0, 0, 0, 0.54)',
+    disabled: 'rgba(0, 0, 0, 0.38)',
+    divider: 'rgba(0, 0, 0, 0.12)'
+  },
+  'on-surface': {
+    high: '#000000',
+    medium: 'rgba(0, 0, 0, 0.54)',
+    disabled: 'rgba(0, 0, 0, 0.38)',
+    divider: 'rgba(0, 0, 0, 0.12)'
+  }
 };
 
 module.exports = colors;

--- a/src/assets/styles/opacities.js
+++ b/src/assets/styles/opacities.js
@@ -1,7 +1,0 @@
-const opacity = {
-  '54': '0.54',
-  '38': '0.38',
-  '12': '0.12'
-};
-
-module.exports = opacity;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,14 +2,12 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 const boxShadow = require('./src/assets/styles/shadows');
 const colors = require('./src/assets/styles/colors');
-const opacity = require('./src/assets/styles/opacities');
 
 module.exports = {
   theme: {
     extend: {
       boxShadow,
-      colors,
-      opacity
+      colors
     },
     fontFamily: {
       sans: ['Roboto', ...defaultTheme.fontFamily.sans]


### PR DESCRIPTION
# Description

This PR indirectly addresses Issue #2 

Previously, we had utilities related to opacity in their own section. However, I think it would be better to meet the opacity-adjustment requirements from our color palette into the actual color utilities. This is so that we can have various elements in the same UI component have varying opacities.

## Example

To style the button in this Figma design with an `on-background-disabled` background but normal opacity CTA text:

![image](https://user-images.githubusercontent.com/20192983/80296494-af73c000-8730-11ea-8bf7-5e7bb282553e.png)

We can apply `bg-on-background-disabled text-error` instead of previously where we had `bg-on-background opacity-38 text-error` which was hard to manage.