### PR TITLE
Feature: Customer View Menu Drawer

### DIFF
--- a/src/assets/styles/animations.css
+++ b/src/assets/styles/animations.css
@@ -1,0 +1,9 @@
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform 0.3s ease;
+}
+
+.slide-enter,
+.slide-leave-to {
+  transform: translateX(-100%);
+}

--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -8,3 +8,4 @@
 @tailwind  utilities;
 
 @import './typography.css';
+@import './animations.css';

--- a/src/components/MenuDrawer.vue
+++ b/src/components/MenuDrawer.vue
@@ -1,0 +1,53 @@
+<template>
+  <div>
+    <div
+      class="bg-on-background-medium fixed inset-x-0 top-0 min-h-screen w-full z-20"
+      @click="toggleMenuDrawer"
+      v-if="isMenuDrawerOpen"
+    />
+    <transition name="slide">
+      <div
+        class="bg-white fixed inset-x-0 top-0 min-h-screen w-4/5 z-30 py-8 px-4"
+        v-if="isMenuDrawerOpen"
+      >
+        <div class="flex flex-col tg-h3-mobile text-left">
+          <div class="pb-8">
+            Home
+          </div>
+          <div class="pb-8">
+            About
+          </div>
+          <div class="pb-8">
+            Services
+          </div>
+          <div class="pb-8">
+            Contact
+          </div>
+          <div class="pb-8">
+            Book Now
+          </div>
+          <div class="pb-8 text-on-background-disabled">
+            Terms of Use
+          </div>
+          <div class="text-on-background-disabled">
+            Privacy Policy
+          </div>
+        </div>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapMutations } from 'vuex';
+
+export default {
+  name: 'MenuDrawer',
+  computed: {
+    ...mapGetters(['isMenuDrawerOpen'])
+  },
+  methods: {
+    ...mapMutations(['toggleMenuDrawer'])
+  }
+};
+</script>

--- a/src/components/MenuHeader.vue
+++ b/src/components/MenuHeader.vue
@@ -2,7 +2,9 @@
   <div
     class="h-14 flex items-center p-5 fixed top-0 z-10 text-on-background-image-high"
   >
-    <MenuIcon class="fill-current w-6 h-6" />
+    <a @click.prevent="toggleMenuDrawer"
+      ><MenuIcon class="fill-current w-6 h-6"
+    /></a>
     <div v-if="tenantName" class="tg-h2-mobile pl-4">
       {{ tenantName }}
     </div>
@@ -11,6 +13,7 @@
 
 <script>
 import MenuIcon from '@/assets/icons/menu.svg';
+import { mapMutations } from 'vuex';
 
 export default {
   name: 'MenuHeader',
@@ -19,6 +22,9 @@ export default {
   },
   props: {
     tenantName: String
+  },
+  methods: {
+    ...mapMutations(['toggleMenuDrawer'])
   }
 };
 </script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,8 +4,19 @@ import Vuex from 'vuex';
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  state: {},
-  mutations: {},
+  state: {
+    isMenuDrawerOpen: false
+  },
+  getters: {
+    isMenuDrawerOpen(state) {
+      return state.isMenuDrawerOpen;
+    }
+  },
+  mutations: {
+    toggleMenuDrawer(store) {
+      store.isMenuDrawerOpen = !store.isMenuDrawerOpen;
+    }
+  },
   actions: {},
   modules: {}
 });

--- a/src/views/customers/Home.vue
+++ b/src/views/customers/Home.vue
@@ -1,8 +1,9 @@
 <template>
   <div id="customer-home" class="min-h-screen flex flex-col">
     <MenuHeader />
+    <MenuDrawer />
     <div
-      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end text-on-background-image-high"
+      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end delay-100 text-on-background-image-high"
     >
       <div class="tg-h2-mobile mb-4">{{ tenantName }}</div>
       <div class="tg-body-mobile mb-4">

--- a/src/views/customers/Home.vue
+++ b/src/views/customers/Home.vue
@@ -22,13 +22,16 @@
 
 <script>
 import MenuHeader from '@/components/MenuHeader.vue';
+import MenuDrawer from '@/components/MenuDrawer.vue';
 import Button from '@/components/ui/Button.vue';
 import CalendarIcon from '@/assets/icons/calendar_today.svg';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'CustomerHome',
   components: {
     MenuHeader,
+    MenuDrawer,
     Button
   },
   props: {
@@ -45,6 +48,9 @@ export default {
     return {
       CalendarIcon
     };
+  },
+  computed: {
+    ...mapGetters(['isMenuDrawerOpen'])
   }
 };
 </script>


### PR DESCRIPTION
**PR not ready to be merged until at least #38 is approved and merged. Not opened as 'Draft' so that deploy preview is accessible**

# Description

This PR addresses Issue #10. We make a basic prototype of what the Customer View - Menu Drawer will look like. We hardcode some dummy data into the view as placeholders.

* 3cf9142: Add slide animation utilities and import them into 'app.css'
* 781e27e: Add state for 'isMenuDrawerOpen' using Vuex, as components on different levels must access menu-drawer-related information
* 295fe5a: Add code for the first iteration of the 'MenuDrawer' component
  * clicking on the 'backdrop' of the component toggles 'isMenuDrawerOpen' in the Vuex store, collapsing the component
* dbbac0f: 'CustomerHome' uses the 'MenuDrawer' component under the 'MenuHeader' component, showing it only if 'isMenuDrawerOpen' is true in Vuex store
* 8db00cf: Clicking the icon in 'MenuHeader' component toggles 'isMenuDrawerOpen' in the Vuex store

### todo (future, when app has more content):

* make a generic shared layout for Customer Views which use the 'MenuHeader' with the 'MenuDrawer'
* put actual router links in the grid units for "Home", "About", "Services", "Contact", etc.
* make separate stores for different parts of the app (e.g. Customer Views, Tenant Views)
* organize routes to be more nested/organized for different parts of the app

# How to test

Go to '/' (redirects to '/shop/test-tenant-slug') and click the hamburger menu icon. It shows the Menu Drawer. Click on the backdrop of the Menu Drawer. It will collapse the Menu Drawer.

![](https://cdn.discordapp.com/attachments/678492548578410497/704902081709998140/image8.gif)