### PR TITLE
Feature: Text and Textarea components (prototype)

### DIFF
--- a/src/assets/styles/app.css
+++ b/src/assets/styles/app.css
@@ -8,3 +8,4 @@
 @tailwind  utilities;
 
 @import './typography.css';
+@import './inputs.css';

--- a/src/assets/styles/inputs.css
+++ b/src/assets/styles/inputs.css
@@ -1,0 +1,13 @@
+.input:focus ~ .label,
+.input:not(:placeholder-shown) ~ .label {
+  font-size: 0.75rem;
+  transform: translateY(-1.25rem);
+}
+
+.line {
+  transform: scale(0);
+}
+
+.input:focus ~ .line {
+  transform: scale(1);
+}

--- a/src/components/inputs/Text.vue
+++ b/src/components/inputs/Text.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="relative tg-body-mobile">
+    <input
+      :id="idName"
+      type="text"
+      placeholder=" "
+      class="input border-b border-current w-full appearance-none outline-none bg-transparent"
+    />
+    <label
+      :for="idName"
+      class="label absolute inset-y-0 left-0 transition-all duration-200"
+    >
+      {{ label }}
+    </label>
+    <div
+      class="line border-t border-current w-full h-px transition-all duration-200"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TextInput',
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+    idName: {
+      type: String,
+      required: true
+    }
+  }
+};
+</script>
+
+<style>
+.input:focus ~ .label,
+.input:not(:placeholder-shown) ~ .label {
+  font-size: 0.75rem;
+  transform: translateY(-1.2rem);
+}
+
+.line {
+  transform: scale(0);
+}
+
+.input:focus ~ .line {
+  transform: scale(1);
+}
+</style>

--- a/src/components/inputs/Text.vue
+++ b/src/components/inputs/Text.vue
@@ -33,19 +33,3 @@ export default {
   }
 };
 </script>
-
-<style>
-.input:focus ~ .label,
-.input:not(:placeholder-shown) ~ .label {
-  font-size: 0.75rem;
-  transform: translateY(-1.2rem);
-}
-
-.line {
-  transform: scale(0);
-}
-
-.input:focus ~ .line {
-  transform: scale(1);
-}
-</style>

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="relative tg-body-mobile">
+    <textarea
+      :id="idName"
+      class="input w-full appearance-none outline-none disable-scrollbar resize-none bg-transparent border-b border-current"
+      placeholder=" "
+      rows="4"
+    />
+    <label
+      :for="idName"
+      class="label absolute top-0 left-0 transition-all duration-200"
+    >
+      {{ label }}
+    </label>
+    <div
+      class="absolute inset-x-0 line border-t border-current w-full h-px transition-all duration-200"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TextAreaInput',
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+    idName: {
+      type: String,
+      required: true
+    }
+  }
+};
+</script>
+
+<style>
+.input:focus ~ .label,
+.input:not(:placeholder-shown) ~ .label {
+  font-size: 0.75rem;
+  transform: translateY(-1.25rem);
+}
+
+.line {
+  bottom: 0.25rem;
+  transform: scale(0);
+}
+
+.input:focus ~ .line {
+  transform: scale(1);
+}
+</style>

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -33,3 +33,15 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.disable-scrollbars::-webkit-scrollbar {
+  width: 0px;
+  background: transparent; /* Chrome/Safari/Webkit */
+}
+
+.disable-scrollbars {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE 10+ */
+}
+</style>

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -13,7 +13,7 @@
       {{ label }}
     </label>
     <div
-      class="absolute inset-x-0 line border-t border-current w-full h-px transition-all duration-200"
+      class="line absolute inset-x-0 bottom-1 border-t border-current w-full h-px transition-all duration-200"
     />
   </div>
 </template>
@@ -33,20 +33,3 @@ export default {
   }
 };
 </script>
-
-<style>
-.input:focus ~ .label,
-.input:not(:placeholder-shown) ~ .label {
-  font-size: 0.75rem;
-  transform: translateY(-1.25rem);
-}
-
-.line {
-  bottom: 0.25rem;
-  transform: scale(0);
-}
-
-.input:focus ~ .line {
-  transform: scale(1);
-}
-</style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,13 +7,16 @@ module.exports = {
   theme: {
     extend: {
       boxShadow,
-      colors
-    },
-    fontFamily: {
-      sans: ['Roboto', ...defaultTheme.fontFamily.sans]
-    },
-    height: {
-      14: '3.5rem'
+      colors,
+      fontFamily: {
+        sans: ['Roboto', ...defaultTheme.fontFamily.sans]
+      },
+      height: {
+        14: '3.5rem'
+      },
+      inset: {
+        1: '0.25rem'
+      }
     }
   },
   variants: {},


### PR DESCRIPTION
# Description

This PR does not address a specific issue per se, but is a step to working on Issue #15. 

We make the first iteration of components that will be used for text and textarea inputs.

Currently, they have no actual data nor validation functionalities in place, these will be added later further along in the project when it is more clear what specific needs for these are. However, please let me know if you spot anything that will be a glaring problem when we attempt to add these functionalities later.

They are based on [Material Input Text Fields](https://vuetifyjs.com/en/components/text-fields/) ("Regular" with no placeholder) and [Material Input Textareas](https://vuetifyjs.com/en/components/textarea/#textareas) ("Default").

They inherit the colors for their label, value, and borders from the parent.

When the user focuses on the input, the form's underline will become thicker and the label will move to an upper-left position. If the user unfocuses without entering a value, the input will return to its initial state. If the user unfocuses after entering a value, the input's underline will return to its initial state, but the label will remain at its upper-left position.

# How to test

Import the components in any component (src/views/customers/Home.vue for example) like so:

![image](https://user-images.githubusercontent.com/20192983/80853463-06bcd900-8be6-11ea-92ce-72d285ef7adb.png)

Observe the behavior of the Text component as described:

![image13](https://user-images.githubusercontent.com/20192983/80854340-4ab2dc80-8bec-11ea-9a87-eed35aaae520.gif)

![image14](https://user-images.githubusercontent.com/20192983/80854341-4dadcd00-8bec-11ea-8f4d-9edd09aaa33f.gif)

Observe the behavior of the TextArea component as described:

![image11](https://user-images.githubusercontent.com/20192983/80854344-59998f00-8bec-11ea-9ced-04f5980eaa6d.gif)

![image12](https://user-images.githubusercontent.com/20192983/80854347-5acabc00-8bec-11ea-974b-19bb05d90c12.gif)

Remark: I noticed that scrollbars were not disabled on TextArea when I took this screencapture, it has since been disabled as of `b098021`