### PR TITLE
Chore: Upgrade Tailwind to 1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3118,7 +3118,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
       "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
@@ -3141,7 +3140,6 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
-      "dev": true,
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -10158,7 +10156,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
       },
@@ -10166,8 +10163,7 @@
         "is-arrayish": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
     },
@@ -10856,13 +10852,16 @@
       }
     },
     "tailwindcss": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.2.0.tgz",
-      "integrity": "sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.4.4.tgz",
+      "integrity": "sha512-49Hy/+WnqQhxtGGjcGlhRlE7+hooX2A0/JOeJnA78fCEqDRlhURWujHY05aCl+lJ6G2qQ+1wlQTg4PqMPUcFVA==",
       "requires": {
+        "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
+        "browserslist": "^4.12.0",
         "bytes": "^3.0.0",
-        "chalk": "^3.0.0",
+        "chalk": "^4.0.0",
+        "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
         "lodash": "^4.17.15",
@@ -10878,6 +10877,15 @@
         "resolve": "^1.14.2"
       },
       "dependencies": {
+        "@fullhuman/postcss-purgecss": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.2.tgz",
+          "integrity": "sha512-Jf34YVBK9GtXTblpu0svNUJdA7rTQoRMz+yEJe6mwTnXDIGipWLzaX/VgU/x6IPC6WvU5SY/XlawwqhxoyFPTg==",
+          "requires": {
+            "postcss": "7.0.27",
+            "purgecss": "^2.1.2"
+          }
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -10887,10 +10895,26 @@
             "color-convert": "^2.0.1"
           }
         },
+        "browserslist": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
+          "integrity": "sha512-UH2GkcEDSI0k/lRkuDSzFl9ZZ87skSy9w2XAn1MsZnL+4c4rqbBd3e82UWHbYDpztABrPBhZsTEeuxVfHppqDg==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001043",
+            "electron-to-chromium": "^1.3.413",
+            "node-releases": "^1.1.53",
+            "pkg-up": "^2.0.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001048",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
+          "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg=="
+        },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -10909,6 +10933,16 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.427",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.427.tgz",
+          "integrity": "sha512-/rG5G7Opcw68/Yrb4qYkz07h3bESVRJjUl4X/FrKLXzoUJleKm6D7K7rTTz8V5LUWnd+BbTOyxJX2XprRqHD8A=="
+        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -10923,6 +10957,17 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "purgecss": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.1.2.tgz",
+          "integrity": "sha512-5oDBxiT9VonwKmEMohPFRFZrj8fdSVKxHPwq7G5Rx/2pXicZFJu+D4m5bb3NuV0sSK3ooNxq5jFIwwHzifP5FA==",
+          "requires": {
+            "commander": "^5.0.0",
+            "glob": "^7.0.0",
+            "postcss": "7.0.27",
+            "postcss-selector-parser": "^6.0.2"
+          }
         },
         "supports-color": {
           "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "core-js": "^3.6.4",
     "register-service-worker": "^1.6.2",
-    "tailwindcss": "^1.2.0",
+    "tailwindcss": "^1.4.4",
     "typeface-roboto": "0.0.75",
     "vue": "^2.6.11",
     "vue-router": "^3.1.5",

--- a/src/assets/styles/colors.js
+++ b/src/assets/styles/colors.js
@@ -5,37 +5,12 @@ const colors = {
   surface: '#F4F1F1',
   action: '#0C6986',
   error: '#C04545',
-  'on-primary': {
-    high: '#0C6986',
-    medium: 'rgba(12, 105, 134, 0.54)',
-    disabled: 'rgba(12, 105, 134, 0.38)',
-    divider: 'rgba(12, 105, 134, 0.12)'
-  },
+  'on-primary': '#0C6986',
   'on-primary-white': '#FFFFFF',
-  'on-secondary': {
-    high: '#0C6986',
-    medium: 'rgba(12, 105, 134, 0.54)',
-    disabled: 'rgba(12, 105, 134, 0.38)',
-    divider: 'rgba(12, 105, 134, 0.12)'
-  },
-  'on-background': {
-    high: '#000000',
-    medium: 'rgba(0, 0, 0, 0.54)',
-    disabled: 'rgba(0, 0, 0, 0.38)',
-    divider: 'rgba(0, 0, 0, 0.12)'
-  },
-  'on-background-image': {
-    high: '#ffffff',
-    medium: 'rgba(255, 255, 255, 0.54)',
-    disabled: 'rgba(255, 255, 255, 0.38)',
-    divider: 'rgba(255, 255, 255, 0.12)'
-  },
-  'on-surface': {
-    high: '#000000',
-    medium: 'rgba(0, 0, 0, 0.54)',
-    disabled: 'rgba(0, 0, 0, 0.38)',
-    divider: 'rgba(0, 0, 0, 0.12)'
-  }
-};
+  'on-secondary':'#0C6986',
+  'on-background': '#000000',
+  'on-background-image': '#ffffff',
+  'on-surface': '#000000'
+}
 
 module.exports = colors;

--- a/src/assets/styles/opacities.js
+++ b/src/assets/styles/opacities.js
@@ -1,0 +1,7 @@
+const opacity = {
+  medium: '0.54',
+  disabled: '0.38',
+  divider: '0.12'
+};
+
+module.exports = opacity;

--- a/src/components/MenuDrawer.vue
+++ b/src/components/MenuDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      class="bg-on-background-medium fixed inset-x-0 top-0 min-h-screen w-full z-20"
+      class="bg-on-background bg-opacity-medium fixed inset-x-0 top-0 min-h-screen w-full z-20"
       @click="toggleMenuDrawer"
       v-if="isMenuDrawerOpen"
     />
@@ -26,10 +26,10 @@
           <div class="pb-8">
             Book Now
           </div>
-          <div class="pb-8 text-on-background-disabled">
+          <div class="pb-8 text-on-background text-opacity-disabled">
             Terms of Use
           </div>
-          <div class="text-on-background-disabled">
+          <div class="text-on-background text-opacity-disabled">
             Privacy Policy
           </div>
         </div>

--- a/src/components/MenuHeader.vue
+++ b/src/components/MenuHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="h-14 flex items-center p-5 fixed top-0 z-10 text-on-background-image-high"
+    class="h-14 flex items-center p-5 fixed top-0 z-10 text-on-background-image"
   >
     <a @click.prevent="toggleMenuDrawer"
       ><MenuIcon class="fill-current w-6 h-6"

--- a/src/views/customers/BusinessHours.vue
+++ b/src/views/customers/BusinessHours.vue
@@ -2,7 +2,7 @@
   <div id="customer-home" class="min-h-screen flex flex-col">
     <MenuHeader :tenantName="tenantName" />
     <div
-      class="p-6 pb-20 flex-grow flex flex-col items-center justify-center text-on-background-image-high"
+      class="p-6 pb-20 flex-grow flex flex-col items-center justify-center text-on-background-image"
     >
       <div class="tg-h1-mobile mb-5">Business Hours</div>
       <div class="tg-body-mobile">

--- a/src/views/customers/Home.vue
+++ b/src/views/customers/Home.vue
@@ -3,7 +3,7 @@
     <MenuHeader />
     <MenuDrawer />
     <div
-      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end delay-100 text-on-background-image-high"
+      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end delay-100 text-on-background-image"
     >
       <div class="tg-h2-mobile mb-4">{{ tenantName }}</div>
       <div class="tg-body-mobile mb-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,12 +2,14 @@ const defaultTheme = require('tailwindcss/defaultTheme');
 
 const boxShadow = require('./src/assets/styles/shadows');
 const colors = require('./src/assets/styles/colors');
+const opacity = require('./src/assets/styles/opacities');
 
 module.exports = {
   theme: {
     extend: {
       boxShadow,
       colors,
+      opacity,
       fontFamily: {
         sans: ['Roboto', ...defaultTheme.fontFamily.sans]
       },


### PR DESCRIPTION
# Description

This PR upgrades our Tailwind package to 1.4.4 from 1.2.0. The main reason for doing this is to take advantage of the new support for utilities for [background](https://tailwindcss.com/docs/background-opacity/) and [text](https://tailwindcss.com/docs/text-opacity/) opacities.

* 87ca818: Update to 'package.json' and 'package-lock.json' for Tailwind
* 2d0ff64: Expand opacity utilities to include 'medium', 'disabled', and 'divider', delete old opacity utilities which used rgba
* 1a34792: Replace old opacity utilities in templates with new ones