### PR TITLE
Feature: Customer View - Contact Form (Prototype)

### DIFF
--- a/src/components/inputs/Text.vue
+++ b/src/components/inputs/Text.vue
@@ -21,12 +21,14 @@
 </template>
 
 <script>
+import { randomId } from '@/helpers.js';
+
 export default {
   name: 'TextInput',
   props: {
     idName: {
       type: String,
-      required: true
+      default: randomId
     },
     label: {
       type: String,

--- a/src/components/inputs/Text.vue
+++ b/src/components/inputs/Text.vue
@@ -2,9 +2,10 @@
   <div class="relative tg-body-mobile">
     <input
       :id="idName"
-      type="text"
+      :type="type"
       placeholder=" "
-      class="input border-b border-current w-full appearance-none outline-none bg-transparent"
+      class="input border-b w-full appearance-none outline-none bg-transparent"
+      :class="inputStyle"
     />
     <label
       :for="idName"
@@ -13,7 +14,8 @@
       {{ label }}
     </label>
     <div
-      class="line border-t border-current w-full h-px transition-all duration-200"
+      class="line border-t w-full h-px transition-all duration-200"
+      :lineStyle="lineStyle"
     />
   </div>
 </template>
@@ -22,13 +24,23 @@
 export default {
   name: 'TextInput',
   props: {
+    idName: {
+      type: String,
+      required: true
+    },
     label: {
       type: String,
       required: true
     },
-    idName: {
+    type: {
       type: String,
-      required: true
+      default: 'text'
+    },
+    inputStyle: {
+      type: Array
+    },
+    lineStyle: {
+      type: Array
     }
   }
 };

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -2,9 +2,10 @@
   <div class="relative tg-body-mobile">
     <textarea
       :id="idName"
-      class="input w-full appearance-none outline-none disable-scrollbar resize-none bg-transparent border-b border-current"
+      class="input w-full appearance-none outline-none disable-scrollbar resize-none bg-transparent border-b"
       placeholder=" "
       rows="4"
+      :textAreaStyle="textAreaStyle"
     />
     <label
       :for="idName"
@@ -13,7 +14,8 @@
       {{ label }}
     </label>
     <div
-      class="line absolute inset-x-0 bottom-1 border-t border-current w-full h-px transition-all duration-200"
+      class="line absolute top-32 border-t-2 w-full h-px transition-all duration-200"
+      :lineStyle="lineStyle"
     />
   </div>
 </template>
@@ -22,13 +24,19 @@
 export default {
   name: 'TextAreaInput',
   props: {
+    idName: {
+      type: String,
+      required: true
+    },
     label: {
       type: String,
       required: true
     },
-    idName: {
-      type: String,
-      required: true
+    textAreaStyle: {
+      type: Array
+    },
+    lineStyle: {
+      type: Array
     }
   }
 };

--- a/src/components/inputs/TextArea.vue
+++ b/src/components/inputs/TextArea.vue
@@ -21,12 +21,14 @@
 </template>
 
 <script>
+import { randomId } from '@/helpers.js';
+
 export default {
   name: 'TextAreaInput',
   props: {
     idName: {
       type: String,
-      required: true
+      default: randomId
     },
     label: {
       type: String,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,5 @@
+export function randomId() {
+  return Math.random()
+    .toString()
+    .substr(2);
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,6 +15,11 @@ const routes = [
     component: () => import('@/views/customers/BusinessHours.vue')
   },
   {
+    path: '/shop/test-tenant-slug/contact',
+    name: 'BusinessHours',
+    component: () => import('@/views/customers/Contact.vue')
+  },
+  {
     path: '/',
     redirect: { name: 'CustomerHome' }
   }

--- a/src/views/customers/BusinessHours.vue
+++ b/src/views/customers/BusinessHours.vue
@@ -1,8 +1,9 @@
 <template>
-  <div id="customer-home" class="min-h-screen flex flex-col">
+  <div id="customer-business-hours" class="min-h-screen flex flex-col">
     <MenuHeader :tenantName="tenantName" />
+    <MenuDrawer />
     <div
-      class="p-6 pb-20 flex-grow flex flex-col items-center justify-center text-on-background-image"
+      class="p-6 flex-grow flex flex-col items-center justify-center text-on-background-image"
     >
       <div class="tg-h1-mobile mb-5">Business Hours</div>
       <div class="tg-body-mobile">
@@ -43,11 +44,13 @@
 
 <script>
 import MenuHeader from '@/components/MenuHeader.vue';
+import MenuDrawer from '@/components/MenuDrawer.vue';
 
 export default {
   name: 'CustomerHome',
   components: {
-    MenuHeader
+    MenuHeader,
+    MenuDrawer
   },
   props: {
     tenantName: {
@@ -61,7 +64,7 @@ export default {
 <style scoped>
 /* temporary scoped css to simulate background until actual background is provided by product */
 
-#customer-home:before {
+#customer-business-hours:before {
   content: '';
   display: block;
   position: absolute;

--- a/src/views/customers/Contact.vue
+++ b/src/views/customers/Contact.vue
@@ -1,0 +1,89 @@
+<template>
+  <div id="customer-contact" class="min-h-screen flex flex-col">
+    <MenuHeader :tenantName="tenantName" />
+    <MenuDrawer />
+    <div
+      class="p-6 flex-grow flex flex-col items-center justify-center text-on-background-image"
+    >
+      <div class="tg-h1-mobile mb-8">Ask us a question</div>
+      <div class="flex flex-col w-full tg-body-mobile">
+        <TextInput idName="name" label="Name" class="w-full pb-8" />
+        <TextInput
+          idName="email"
+          label="Email"
+          type="email"
+          class="w-full pb-8"
+          :inputStyle="['border-opacity-medium']"
+          :lineStyle="['border-opacity-medium']"
+        />
+        <TextAreaInput idName="message" label="Message" class="w-full pb-8" />
+        <Button
+          :icon="SendIcon"
+          ctaText="Send"
+          class="border mb-8 w-full"
+          :iconStyle="['opacity-medium']"
+          :textAreaStyle="['border-opacity-medium']"
+          :lineStyle="['border-opacity-medium']"
+        />
+        <div class="tg-caption-mobile">
+          {{ tenantName }} will receive an email and a text with your message.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import MenuHeader from '@/components/MenuHeader.vue';
+import MenuDrawer from '@/components/MenuDrawer.vue';
+import TextInput from '@/components/inputs/Text.vue';
+import TextAreaInput from '@/components/inputs/TextArea.vue';
+import Button from '@/components/ui/Button.vue';
+import SendIcon from '@/assets/icons/send.svg';
+
+export default {
+  name: 'CustomerHome',
+  components: {
+    MenuHeader,
+    MenuDrawer,
+    TextInput,
+    TextAreaInput,
+    Button
+  },
+  props: {
+    tenantName: {
+      type: String,
+      default: 'Carissa Queen'
+    }
+  },
+  data() {
+    return {
+      SendIcon
+    };
+  }
+};
+</script>
+
+<style scoped>
+/* temporary scoped css to simulate background until actual background is provided by product */
+
+#customer-contact:before {
+  content: '';
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  opacity: 0.75;
+  background-image: url('https://i.pinimg.com/originals/80/29/6b/80296b1e27351233d5d82104b3e02a92.jpg');
+  background-repeat: no-repeat;
+  background-position: 50% 0;
+  -ms-background-size: cover;
+  -o-background-size: cover;
+  -moz-background-size: cover;
+  -webkit-background-size: cover;
+  background-size: cover;
+}
+</style>

--- a/src/views/customers/Home.vue
+++ b/src/views/customers/Home.vue
@@ -3,7 +3,7 @@
     <MenuHeader />
     <MenuDrawer />
     <div
-      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end delay-100 text-on-background-image"
+      class="p-6 pb-20 flex-grow flex flex-col items-center justify-end text-on-background-image"
     >
       <div class="tg-h2-mobile mb-4">{{ tenantName }}</div>
       <div class="tg-body-mobile mb-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
         14: '3.5rem'
       },
       inset: {
-        1: '0.25rem'
+        32: '5rem'
       }
     }
   },


### PR DESCRIPTION
# Description

This PR addresses Issue #15. We make a basic prototype of what the Customer View - Contact Form will look like. The form itself is non-functional and does not transfer data at the moment.

* c43648d: We make the 'Text' input component more configurable by allowing 'type', 'textStyle', and 'lineStyle' as props. 'type' was needed to make the input type email, tel, etc. 'textStyle' and 'lineStyle' were needed because Figma designs indicated the need for specifications of border opacities.
* e5fb2ba: Similar to above, we add 'textAreaStyle' and 'lineStyle' as props. We also fix the appearing underline position to be calculated from the top instead of the bottom as pudding padding bottom on the 'TextArea' component was breaking the underline visuals.
* 570ad25: We do miscellaneous cleaning up of the 'BusinessHours' and 'Home' views including ID names, removing unnecessary classes, adding in the 'MenuDrawer' component where it was absent but needed, etc.
* 46a8f74: We add the first iteration of the Customer View - Contact Form component and add the placeholder route to access it from '/shop/test-tenant-slug/contact'

# How to test

Go to ['/shop/test-tenant-slug/contact'](https://deploy-preview-42--browtricks.netlify.app/shop/test-tenant-slug/contact) and see the result. (Link goes to Deploy Preview)