### PR TITLE
Chore: Move MenuDrawer Component

### DIFF
--- a/src/assets/styles/colors.js
+++ b/src/assets/styles/colors.js
@@ -7,7 +7,7 @@ const colors = {
   error: '#C04545',
   'on-primary': '#0C6986',
   'on-primary-white': '#FFFFFF',
-  'on-secondary':'#0C6986',
+  'on-secondary': '#0C6986',
   'on-background': '#000000',
   'on-background-image': '#ffffff',
   'on-surface': '#000000'

--- a/src/components/MenuDrawer.vue
+++ b/src/components/MenuDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="text-on-surface">
     <div
       class="bg-on-background bg-opacity-medium fixed inset-x-0 top-0 min-h-screen w-full z-20"
       @click="toggleMenuDrawer"

--- a/src/components/MenuHeader.vue
+++ b/src/components/MenuHeader.vue
@@ -8,17 +8,20 @@
     <div v-if="tenantName" class="tg-h2-mobile pl-4">
       {{ tenantName }}
     </div>
+    <MenuDrawer />
   </div>
 </template>
 
 <script>
 import MenuIcon from '@/assets/icons/menu.svg';
+import MenuDrawer from '@/components/MenuDrawer.vue';
 import { mapMutations } from 'vuex';
 
 export default {
   name: 'MenuHeader',
   components: {
-    MenuIcon
+    MenuIcon,
+    MenuDrawer
   },
   props: {
     tenantName: String

--- a/src/views/customers/Home.vue
+++ b/src/views/customers/Home.vue
@@ -1,7 +1,6 @@
 <template>
   <div id="customer-home" class="min-h-screen flex flex-col">
     <MenuHeader />
-    <MenuDrawer />
     <div
       class="p-6 pb-20 flex-grow flex flex-col items-center justify-end delay-100 text-on-background-image"
     >
@@ -22,7 +21,6 @@
 
 <script>
 import MenuHeader from '@/components/MenuHeader.vue';
-import MenuDrawer from '@/components/MenuDrawer.vue';
 import Button from '@/components/ui/Button.vue';
 import CalendarIcon from '@/assets/icons/calendar_today.svg';
 import { mapGetters } from 'vuex';
@@ -31,7 +29,6 @@ export default {
   name: 'CustomerHome',
   components: {
     MenuHeader,
-    MenuDrawer,
     Button
   },
   props: {


### PR DESCRIPTION
# Description

While working on #42, I had to import both 'MenuHeader' and 'MenuDrawer' components for every customer view that was being implemented. While I don't think making a Customer View layout is necessary, I think instantiating 'MenuDrawer' inside of 'MenuHeader' makes sense to simplify 'MenuHeader' usage.

* ee2c4a8: Add a black text color specification to 'MenuDrawer' to override white text color of 'MenuHeader' being applied to it.
* 37d4f27: Move the 'MenuDrawer' component out of Customer 'Home' component and into 'MenuHeader' component

# How to test

Go to '/' and observe that the hamburger menu functionality has not changed. (Links were not implemented prior to this, so only opening and closing the menu should work)