### PR TITLE
Fix: disable double tap to zoom on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>


### PR DESCRIPTION
# Description

This PR does not address a specific issue. We disable double-tap to zoom when viewing on mobile devices.

We follow the Volkswagen implementation of this: [here](https://github.com/whynotearth/Volkswagen-email-corporate-communications-CMS/blob/staging/public/index.html)

# How to test

Open any view, e.g. [here](https://deploy-preview-50--browtricks.netlify.app/) and observe that double tapping the screen no longer zooms in

(Link will take you to deploy preview of '/')