### PR TITLE
Feature: Customer View - Category Page (Prototype)

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,6 +20,11 @@ const routes = [
     component: () => import('@/views/CustomerContact.vue')
   },
   {
+    path: '/shop/test-tenant-slug/categories',
+    name: 'CustomerCategories',
+    component: () => import('@/views/CustomerCategories.vue')
+  },
+  {
     path: '/',
     redirect: { name: 'CustomerHome' }
   }

--- a/src/views/CustomerCategories.vue
+++ b/src/views/CustomerCategories.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="customer-view">
+    <LayoutFixedScrollable>
+      <BaseHeader
+        slot="header"
+        class="text-on-background-image"
+        @iconClicked="toggleMenuDrawer"
+      >
+        <IconMenu slot="icon" class="h-6 w-6 fill-current" />
+        <span slot="content" class="pl-5">{{ tenantName }}</span>
+        <CustomerMenuDrawer slot="menu-drawer" />
+      </BaseHeader>
+      <div slot="content" class="p-6 text-on-background-image">
+        <BaseLineItem class="mb-8">
+          <span slot="title">Eyebrow PMU Services</span>
+        </BaseLineItem>
+        <BaseLineItem class="mb-8">
+          <span slot="title">Permanent Eyeliner</span>
+        </BaseLineItem>
+        <BaseLineItem class="mb-8">
+          <span slot="title">Lip Blush</span>
+        </BaseLineItem>
+        <BaseLineItem class="mb-8">
+          <span slot="title">Microneedling</span>
+        </BaseLineItem>
+      </div>
+    </LayoutFixedScrollable>
+  </div>
+</template>
+
+<script>
+import LayoutFixedScrollable from '@/components/LayoutFixedScrollable.vue';
+import BaseHeader from '@/components/BaseHeader.vue';
+import IconMenu from '@/assets/icons/menu.svg';
+import CustomerMenuDrawer from '@/components/CustomerMenuDrawer.vue';
+import BaseLineItem from '@/components/BaseLineItem.vue';
+import { mapGetters, mapMutations } from 'vuex';
+
+export default {
+  name: 'CustomerCategories',
+  components: {
+    LayoutFixedScrollable,
+    BaseHeader,
+    IconMenu,
+    CustomerMenuDrawer,
+    BaseLineItem
+  },
+  computed: {
+    ...mapGetters({
+      tenantName: 'getTenantName'
+    })
+  },
+  methods: {
+    ...mapMutations(['toggleMenuDrawer'])
+  }
+};
+</script>


### PR DESCRIPTION
This PR addresses Issue #45. We make a basic prototype of what the Customer View - Category Page will look like. I think each "BaseLineItem" component will be wrapped in a `router-link` in the actual implementation.

# Commits

7602217: Add the prototypical "Customer View - Category Page"

836dfb0: Add a test route for the above view - "/shop/test-tenant-slug/categories"

# How to Test

Go to ["/shop/test-tenant-slug/categories"](https://deploy-preview-51--browtricks.netlify.app/shop/test-tenant-slug/categories) and see the result. (Link goes to Netlify deploy preview)