### PR TITLE
Meta - Bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: "Found a bug? \U0001F41B Let us know!"
+title: "[BUG] (Your bug report title here)"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
# Description

We make a bug report issue template for better documentation of bugs, which in turn will help developers fix bugs more effectively.

View the easier-to-read markdown version [here](https://github.com/whynotearth/BrowTricks/blob/2a6499a67785d2cd9ebd02fae3d9b2df83df5b42/.github/ISSUE_TEMPLATE/bug_report.md).

One thing that I wasn't sure on was whether or not to automatically apply the 'bug' label to any issues that use this template.