### PR TITLE
Meta: Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: "Found a bug? \U0001F41BLet us know!"
+title: "[BUG] (Write bug report title here)"
+labels: bug
+assignees: ''
+
+---
+
+# Location
+
+Where in the app did you encounter the bug?
+
+# Expected Behavior
+
+What did you expected would happen?
+
+# Actual Behavior
+
+What happened instead?
+
+# Browser, Device, OS and Versions
+
+What browser, device, and operating system were you on? What versions? e.g. Safari 13, iPhone 11, iOS 13.0
+
+# Steps to Reproduce
+
+What are the steps to reliably reproduce the bug? e.g.
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+# Screenshots/casts
+
+Provide any additional screenshots/screencasts that you think would help explain/treat the problem.
+
+# Additional Context
+
+Provide any additional notes here that you think would help explain/treat the problem.


### PR DESCRIPTION
# Description

We add an issue template for those wanting to report bugs. This should help communication between reporters and fixers.

Go [here](https://github.com/whynotearth/BrowTricks/blob/a6fc4da9e52561e190a8069818cc4e48b33d7073/.github/ISSUE_TEMPLATE/bug-report.md) to see a version of the template that is easier on the eyes than the diff.