### PR TITLE
Meta: Pull Request Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,26 @@
-Addresses the following issue(s): # .
+# Issue Being Addressed
 
-# What kind of PR is this? (check all that apply)
+Put the issue(s) # that your PR is addressing here. e.g. #15, #29
 
+# Type of PR
+
+Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.
+
+- [ ] Bug Fix
 - [ ] Refactor
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Feature update
+- [ ] New Feature
+- [ ] Update to Existing Feature
 - [ ] Other (state below)
 
 # Description
 
-For refactors: What are we refactoring and why? How do your changes address the need for refactoring?
+*For Bug Fixes:* What was the root cause? How do your changes fix the bug effectively?
 
-For bug fixes: What was the root cause? How do your changes fix the bug effectively?
+*For Refactors:* What are we refactoring and why? How do your changes address this need for refactoring?
 
-For new features: What feature are we adding? Explain your technical approach to doing this.
+*For New Features:* What feature are we adding? Explain your technical approach to doing this.
 
-For feature updates: What feature are we updating? Explain your technical approach to doing this.
+*For Feature Updates:* What feature are we updating? Explain your technical approach to doing this.
 
 # How to Test/Reproduce
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+Addresses the following issue(s): # .
+
+# What kind of PR is this? (check all that apply)
+
+- [ ] Refactor
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Feature update
+- [ ] Other (state below)
+
+# Description
+
+For refactors: What are we refactoring and why? How do your changes address the need for refactoring?
+
+For bug fixes: What was the root cause? How do your changes fix the bug effectively?
+
+For new features: What feature are we adding? Explain your technical approach to doing this.
+
+For feature updates: What feature are we updating? Explain your technical approach to doing this.
+
+# How to Test/Reproduce
+
+Provide steps on how one can test your changes here. e.g.
+1. Log in as '...'
+2. Go to '...'
+3. Click on '...'
+4. See the updated element x
+
+# Screenshots/casts
+
+If applicable, include any relevant screenshot or screencasts of your changes.
+
+# Additional Context
+
+Provide any additional notes that you think would help effective review of your code.


### PR DESCRIPTION
# Description

We add a pull request template to be regularly used by developers working on the project. This should help PR descriptions be more focused and thorough which should help produce faster and more effective reviews which should help the codebase be more navigable, extendable, rack up less tech debt, etc. :)

Go [here](https://github.com/whynotearth/BrowTricks/blob/bc76c092dda1f8c2fee1b738a9c67d0f7ce3c89c/.github/pull_request_template.md) to view the template in markdown form, which should be easier to read than in diff form.

Any and all feedback appreciated, especially from other devs. 