### PR TITLE
Fix: loading spinner should have secondary color

### DIFF
--- a/src/assets/styles/animations.css
+++ b/src/assets/styles/animations.css
@@ -9,7 +9,7 @@
 }
 
 .loading {
-  @apply border-action border-4 rounded-full w-10 h-10;
+  @apply border-secondary border-4 rounded-full w-10 h-10;
   animation: spin 500ms linear infinite;
   border-bottom-color: transparent;
   border-right-color: transparent;


### PR DESCRIPTION
Quickly updating the spinner color to have the `secondary` color instead of `action`. Product and I were having a discussion about the appropriate color and I forgot to change it back to its intended color.