### PR TITLE
Splash Layout

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -1,14 +1,12 @@
 <template>
   <component
     :is="tag"
-    class="full-width rounded-full tg-color-label-mobile p-2 flex items-center justify-center"
+    class="w-full rounded-full tg-color-label-mobile px-4 py-2 flex items-center justify-center"
     @click="$emit('clicked')"
     :href="href"
     :to="to"
   >
-    <div class="text-left h-6 w-6">
-      <slot name="icon" />
-    </div>
+    <slot name="icon" />
     <div class="flex-grow">
       <slot name="cta-text">
         Button

--- a/src/components/LayoutSplash.vue
+++ b/src/components/LayoutSplash.vue
@@ -1,6 +1,27 @@
 <template>
-  <div class="h-full flex flex-col justify-end">
-    test
+  <div
+    class="layout-splash h-full flex flex-col justify-end items-center p-4 pb-5 text-on-background-image"
+  >
+    <slot name="image" />
+    <div class="tg-h1-mobile">
+      <slot name="title" />
+    </div>
+    <div class="tg-body-mobile">
+      <slot name="subtitle" />
+    </div>
+    <div class="tg-body-hyperlink-mobile text-secondary">
+      <slot name="link" />
+    </div>
+    <slot name="primary-cta" />
+    <slot name="secondary-cta" />
+    <div class="tg-color-label-mobile text-error">
+      <slot name="reject-cta" />
+    </div>
+    <div
+      class="tg-body-hyperlink-mobile text-on-background-image text-opacity-medium"
+    >
+      <slot name="tertiary-cta" />
+    </div>
   </div>
 </template>
 
@@ -9,3 +30,11 @@ export default {
   name: 'LayoutSplash'
 };
 </script>
+
+<style scoped>
+.layout-splash {
+  background-image: url('https://res.cloudinary.com/whynotearth/image/upload/v1590460151/BrowTricks/Action_page_background_zlpen3.png');
+
+  @apply bg-cover bg-no-repeat;
+}
+</style>

--- a/src/components/LayoutSplash.vue
+++ b/src/components/LayoutSplash.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="h-full flex flex-col justify-end">
+    test
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'LayoutSplash'
+};
+</script>

--- a/src/components/LayoutSplash.vue
+++ b/src/components/LayoutSplash.vue
@@ -1,24 +1,24 @@
 <template>
   <div
-    class="layout-splash h-full flex flex-col justify-end items-center p-4 pb-5 text-on-background-image"
+    class="layout-splash h-full flex flex-col justify-end items-center p-4 pb-10 text-on-background-image"
   >
     <slot name="image" />
-    <div class="tg-h1-mobile">
+    <div class="tg-h1-mobile pb-4">
       <slot name="title" />
     </div>
-    <div class="tg-body-mobile">
+    <div class="tg-body-mobile pb-4">
       <slot name="subtitle" />
     </div>
-    <div class="tg-body-hyperlink-mobile text-secondary">
+    <div class="tg-body-hyperlink-mobile text-secondary pb-4">
       <slot name="link" />
     </div>
-    <slot name="primary-cta" />
-    <slot name="secondary-cta" />
-    <div class="tg-color-label-mobile text-error">
+    <div class="pb-4"><slot name="primary-cta" /></div>
+    <div class="pb-4"><slot name="secondary-cta" /></div>
+    <div class="tg-color-label-mobile text-error pb-4">
       <slot name="reject-cta" />
     </div>
     <div
-      class="tg-body-hyperlink-mobile text-on-background-image text-opacity-medium"
+      class="tg-body-hyperlink-mobile text-on-background-image text-opacity-medium pb-4"
     >
       <slot name="tertiary-cta" />
     </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,11 @@ Vue.use(VueRouter);
 
 const routes = [
   {
+    path: '/test-layout-splash',
+    name: 'TestLayoutSplash',
+    component: () => import('@/views/TestLayoutSplash.vue')
+  },
+  {
     path: '/shop/test-tenant-slug',
     name: 'CustomerHome',
     component: () => import('@/views/CustomerHome.vue')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,11 @@ const routes = [
     component: () => import('@/views/TestLayoutSplash.vue')
   },
   {
+    path: '/test-layout-splash-with-header',
+    name: 'TestLayoutSplashWithHeader',
+    component: () => import('@/views/TestLayoutSplashWithHeader.vue')
+  },
+  {
     path: '/shop/test-tenant-slug',
     name: 'CustomerHome',
     component: () => import('@/views/CustomerHome.vue')

--- a/src/views/CustomerContact.vue
+++ b/src/views/CustomerContact.vue
@@ -28,7 +28,7 @@
             Message
           </BaseInputTextArea>
           <BaseButton class="border mb-8 w-full">
-            <IconSend slot="icon" class="fill-current opacity-medium" />
+            <IconSend slot="icon" class="fill-current opacity-medium h-6 w-6" />
             <span slot="cta-text">Send</span>
           </BaseButton>
           <div class="tg-caption-mobile">

--- a/src/views/CustomerHome.vue
+++ b/src/views/CustomerHome.vue
@@ -16,7 +16,7 @@
         </div>
         <div class="w-full px-3">
           <BaseButton class="border border-solid">
-            <IconCalendar slot="icon" class="fill-current" />
+            <IconCalendar slot="icon" class="fill-current h-6 w-6" />
             <span slot="cta-text">Book Now</span>
           </BaseButton>
         </div>

--- a/src/views/TestLayoutSplash.vue
+++ b/src/views/TestLayoutSplash.vue
@@ -7,20 +7,20 @@
           src="https://res.cloudinary.com/whynotearth/image/upload/v1585738962/BrowTricks/LOG_IN_alwajv.png"
           class="w-40 h-45 pb-14"
         />
-        <div slot="title" class="pb-4">Brow Tricks Beauty</div>
-        <div slot="subtitle" class="pb-4">This is a test</div>
-        <div slot="link" class="pb-4">This is a test</div>
-        <div slot="primary-cta" class="w-full pb-4">
+        <div slot="title">Brow Tricks Beauty</div>
+        <div slot="subtitle">This is a test</div>
+        <div slot="link">This is a test</div>
+        <div slot="primary-cta" class="w-full">
           <BaseButton class="bg-secondary">
             <span slot="cta-text">Start Setting Up Your Business</span>
           </BaseButton>
         </div>
-        <div slot="secondary-cta" class="w-full pb-6">
+        <div slot="secondary-cta" class="w-full">
           <BaseButton class="bg-secondary">
             <span slot="cta-text">Start Setting Up Your Business</span>
           </BaseButton>
         </div>
-        <div slot="reject-cta" class="pb-4">Cancel Action</div>
+        <div slot="reject-cta">Cancel Action</div>
         <div slot="tertiary-cta">
           No account? Sign Up For Brow Tricks Beauty!
         </div>

--- a/src/views/TestLayoutSplash.vue
+++ b/src/views/TestLayoutSplash.vue
@@ -1,0 +1,9 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  name: 'TestLayoutSplash'
+};
+</script>

--- a/src/views/TestLayoutSplashWithHeader.vue
+++ b/src/views/TestLayoutSplashWithHeader.vue
@@ -1,6 +1,10 @@
 <template>
   <div>
     <LayoutFixedScrollable>
+      <BaseHeader slot="header" class="text-on-background-image bg-secondary">
+        <IconMenu slot="icon" class="h-6 w-6 fill-current" />
+        <span slot="content" class="pl-5">Menu</span>
+      </BaseHeader>
       <LayoutSplash slot="content">
         <img
           slot="image"
@@ -31,15 +35,19 @@
 
 <script>
 import LayoutFixedScrollable from '@/components/LayoutFixedScrollable.vue';
+import BaseHeader from '@/components/BaseHeader.vue';
 import LayoutSplash from '@/components/LayoutSplash.vue';
 import BaseButton from '@/components/BaseButton.vue';
+import IconMenu from '@/assets/icons/menu.svg';
 
 export default {
   name: 'TestLayoutSplash',
   components: {
     LayoutFixedScrollable,
+    BaseHeader,
     LayoutSplash,
-    BaseButton
+    BaseButton,
+    IconMenu
   }
 };
 </script>


### PR DESCRIPTION
# Issue Being Addressed

This issue aids in the completion of #76 

# Type of PR

[ ] Bug Fix
[ ] Refactor
[x] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description

## New Features

Relevant files changed: 

* src/components/LayoutSplash.vue
* src/views/TestLayoutSplash.vue
* src/views/TestLayoutSplashWithHeader.vue
* src/router/index.js

Note: All test views and routes will be removed before merging of this PR.

We add a new layout called 'Splash' based on the master component provided by product design:

![image](https://user-images.githubusercontent.com/20192983/84438463-71046880-abeb-11ea-8a4e-e03b30902c7d.png)

We make it a component called 'LayoutSplash' and have slots for the following:

![image](https://user-images.githubusercontent.com/20192983/84439015-54b4fb80-abec-11ea-9e15-8183ffed12bb.png)

Along with an additional slot for one piece of text that did not show up in the master component at the time of screenshot:

![image](https://user-images.githubusercontent.com/20192983/84439246-b83f2900-abec-11ea-8c5c-75896637725d.png)

Product has stated that 'splash' views will have all of their content bottom-aligned with content growing upward (mainly for ease of tapping CTAs when on mobile).

## Feature Updates 

Relevant files changed:

* src/components/BaseButton.vue
* src/components/CustomerContact.vue
* src/components/CustomerHome.vue

We had the icon container for buttons unnecessarily taking up left space even if there was no icon. This caused buttons with no icons to have strange text alignment. We fix this by taking out the mandated height and width on the icon container on the button component.

We had a class called `full-width` but it was meant to be `w-full`. We fix this on the button component.

We go back and put a fixed height and width on the SVG components in button component instantiations.

# How to Test/Reproduce

1. Go to `/test-layout-splash` to view an example of the Splash layout with no header with all of its slots filled.
2. Go to `/test-layout-splash-with-header` to view an example of the Splash layout with header with all of its slots filled.

# Screenshots/casts

/test-layout-splash:

![image](https://user-images.githubusercontent.com/20192983/84439629-6cd94a80-abed-11ea-8b40-8174db75393f.png)

/test-layout-splash-with-header

![image](https://user-images.githubusercontent.com/20192983/84439652-795da300-abed-11ea-8830-f08fd264f9ee.png)