### PR TITLE
[Don't Merge] twilio - add text to mobile (by sms) to sign page

### DIFF
--- a/src/views/ClientEdit.vue
+++ b/src/views/ClientEdit.vue
@@ -121,24 +121,6 @@
         <ImagesIcon slot="preIcon" class="h-6 w-6 fill-current" />
       </ExpansionPanel>
 
-      <!-- incompleted PMU -->
-      <!-- TODO: enable -->
-      <!-- <ExpansionPanel
-        v-if="isPmuIncomplete"
-        @click="
-          $router.push({
-            name: 'PmuSignMethods',
-            params: { clientId, tenantSlug }
-          })
-        "
-        title="PMU"
-        :middleText="client.pmuStatus"
-      >
-        <Document slot="preIcon" class="h-6 w-6 fill-current" />
-      </ExpansionPanel> -->
-
-      <!-- completed PMU -->
-      <!-- v-else -->
       <ExpansionPanel
         @click="
           $router.push({

--- a/src/views/PmuSign.vue
+++ b/src/views/PmuSign.vue
@@ -64,6 +64,12 @@
         @clicked="submit"
         title="Get Started"
       ></Button>
+
+      <Button
+        class="rounded-full mb-6"
+        :title="`Text to ${client.phoneNumber}`"
+        @clicked="sendSms"
+      />
     </template>
 
     <template v-else-if="pmuPdfUrl">
@@ -120,7 +126,12 @@ export default {
   },
   methods: {
     ...mapActions('client', ['fetchClient']),
-    ...mapActions('PMU', ['setCustomQuestions', 'submitSign', 'signed']),
+    ...mapActions('PMU', [
+      'setCustomQuestions',
+      'submitSign',
+      'signed',
+      'notify'
+    ]),
 
     async _fetchClient() {
       this.client = await this.fetchClient({
@@ -184,6 +195,26 @@ export default {
     },
     prepareQuestions() {
       return this.questions.filter(q => q.value.length > 0).map(q => q.value);
+    },
+
+    sendSms() {
+      const path = this.$router.resolve({
+        name: 'PmuSignFromNotify'
+      }).href;
+      const callbackUrl = `${window.location.origin}${path}`;
+      console.log('callbackUrl', callbackUrl);
+      this.notify({
+        params: {
+          clientId: this.clientId,
+          tenantSlug: this.tenantSlug,
+          callbackUrl
+        }
+      }).then(() => {
+        showOverlayAndRedirect({
+          title: 'Message Sent Successfully!',
+          route: { name: 'ClientEdit' }
+        });
+      });
     }
   }
 };


### PR DESCRIPTION
# Issue Being Addressed

This is related to #185 but won't finish it. I just wanted to put sending SMS button somewhere to test Twilio.

# Type of PR

[ ] Bug Fix
[ ] Refactor
[x] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?

**For Refactors:** What are we refactoring and why? How do your changes address this need for refactoring?

**For New Features:** What feature are we adding? Explain your technical approach to doing this.    
Add "Text to {phone}" button to PMU sign page.

**For Feature Updates:** What feature are we updating? Explain your technical approach to doing this.

**For Other:** State what 'type' of PR yours is and elaborate on the PR's technical content.

# How to Test/Reproduce

Go to client page, click on PMU, there is a new "Text to {phone}" button.

