### PR TITLE
Fix cloudinary loading state which was causing error

### DIFF
--- a/src/components/DrawerUpload.vue
+++ b/src/components/DrawerUpload.vue
@@ -8,11 +8,13 @@
           :files="currentFiles"
           @change="updateFiles"
           :uploadPreset="uploadPresetImage"
+          @widget-ready="cloudinaryWidgetImageIsLoaded = true"
         >
           <a
             tabindex="0"
             class="flex justify-between w-full p-4 cursor-pointer"
             aria-labelledby="link-upload-image"
+            :class="[!cloudinaryWidgetImageIsLoaded ? 'opacity-disabled' : '']"
           >
             <span class="flex items-center">
               <IconImages
@@ -34,11 +36,13 @@
           :files="currentFiles"
           @change="updateFiles"
           :uploadPreset="uploadPresetVideo"
+          @widget-ready="cloudinaryWidgetVideoIsLoaded = true"
         >
           <a
             tabindex="0"
             class="flex justify-between w-full p-4 cursor-pointer"
             aria-labelledby="link-upload-video"
+            :class="[!cloudinaryWidgetVideoIsLoaded ? 'opacity-disabled' : '']"
           >
             <span class="flex items-center">
               <IconVideos
@@ -70,6 +74,8 @@ export default {
   components: { MediaUploader, BaseDrawerActions, IconImages, IconVideos },
   data() {
     return {
+      cloudinaryWidgetImageIsLoaded: false,
+      cloudinaryWidgetVideoIsLoaded: false,
       uploadPresetImage: process.env.VUE_APP_UPLOADER_IMAGE_PRESET,
       uploadPresetVideo: process.env.VUE_APP_UPLOADER_VIDEO_PRESET,
       client: null

--- a/src/components/uploader/MediaUploader.vue
+++ b/src/components/uploader/MediaUploader.vue
@@ -1,5 +1,6 @@
 <template>
   <CloudinaryWidget
+    @widget-ready="$emit('widget-ready')"
     @uploaded="onUpload"
     :uploadPreset="uploadPreset"
     @error="onUploadError"


### PR DESCRIPTION
# Issue Being Addressed

No issue

# Type of PR

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?  
When the Cloudinary script is loading, we disable Image/Video upload links, after loading the external script of Cloudinary, the opacity of links returns to normal and are clickable.

# How to Test/Reproduce

Hard refresh page (to clear cache) and click ➕ button in navigation.  
See the opacity and click on Image/Video links.

# Screenshots/casts

![localhost_8080_tenant_tttest-110_clients(Moto G4)](https://user-images.githubusercontent.com/510242/91586566-cfc7bb80-e96a-11ea-8072-51fcc69dfb8b.png)

