### PR TITLE
Hotfix: added outside click functionality #246

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash-es": "^4.17.15",
     "register-service-worker": "^1.6.2",
     "tailwindcss": "^1.4.4",
+    "v-click-outside": "^3.1.0",
     "vue": "^2.6.11",
     "vue-100vh": "^0.1.1",
     "vue-router": "^3.1.5",

--- a/src/layouts/WithTitleBarLayout.vue
+++ b/src/layouts/WithTitleBarLayout.vue
@@ -2,6 +2,7 @@
   <div class="page min-h-screen flex flex-col text-white text-opacity-medium">
     <header
       class="bg-primary z-20 shadow-4dp flex flex-row items-center p-4 sticky top-0"
+      v-click-outside="onClickOutside"
     >
       <!-- icon -->
       <h1 class="tg-h2-mobile text-opacity-high flex-grow text-white ml-2">
@@ -125,12 +126,15 @@ export default {
       });
     },
     navigateTo(value) {
-      this.showOverFlowMenu = false;
+      this.onClickOutside();
       let params = this.$route.params;
       this.$router.push({
         name: value,
         params: { clientId: params.clientId, tenantSlug: params.tenantSlug }
       });
+    },
+    onClickOutside() {
+      this.showOverFlowMenu = false;
     }
   },
   watch: {

--- a/src/layouts/WithTitleBarLayout.vue
+++ b/src/layouts/WithTitleBarLayout.vue
@@ -110,6 +110,7 @@ export default {
     init() {
       this.handleBackRoute();
       this.handleTitle();
+      this.onClickOutside();
     },
     handleTitle() {
       this.currentTitle = this.$route.meta.title;

--- a/src/layouts/WithTitleBarLayout.vue
+++ b/src/layouts/WithTitleBarLayout.vue
@@ -2,7 +2,6 @@
   <div class="page min-h-screen flex flex-col text-white text-opacity-medium">
     <header
       class="bg-primary z-20 shadow-4dp flex flex-row items-center p-4 sticky top-0"
-      v-click-outside="onClickOutside"
     >
       <!-- icon -->
       <h1 class="tg-h2-mobile text-opacity-high flex-grow text-white ml-2">
@@ -22,6 +21,7 @@
         />
       </router-link>
       <a
+        v-click-outside="onClickOutside"
         class="cursor-pointer self-center"
         v-else-if="$route.meta.menuItems"
         @click.prevent="showOverFlowMenu = true"

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import router from './router';
 import store from './store';
 import './assets/styles/app.css';
 import Vuelidate from 'vuelidate';
+import vClickOutside from 'v-click-outside';
 import configureModerator from './store/store-moderator';
 
 import SmoothPicker from 'vue-smooth-picker';
@@ -13,6 +14,7 @@ import 'vue-smooth-picker/dist/css/style.css';
 
 Vue.use(SmoothPicker);
 Vue.use(Vuelidate);
+Vue.use(vClickOutside);
 
 Vue.config.productionTip = false;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8313,6 +8313,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+v-click-outside@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/v-click-outside/-/v-click-outside-3.1.0.tgz#941be55f54982291b2e1beaa8447e5830b7afe29"
+  integrity sha512-WZBeCxHjmL67+dpw4GTNwNWoCUsyjvP4bO0xFLCEPIYqWhigQso28NKasfvg4vDYn7fUvMigFmKf+mV42lbJ2Q==
+
 v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"


### PR DESCRIPTION
# Issue Being Addressed
#246 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?
Before there was no way to close the overflow menu when clicked anywhere on the screen.
Added the v-outside-click library which fixed the problem.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Log in with your account
2. Go to the client's page
3. Click on the overflow menu first
4. Click on edit profile 
5. The overflow menu should not be visible.
