### PR TITLE
WIP pmu - add error handling in sign flow, redirect to pmu sign result

### DIFF
--- a/src/components/BaseStepperTopBar.vue
+++ b/src/components/BaseStepperTopBar.vue
@@ -44,6 +44,8 @@
 </template>
 
 <script>
+import { get } from 'lodash-es';
+
 export default {
   name: 'CheckoutStepper',
   props: {
@@ -63,10 +65,12 @@ export default {
   },
   methods: {
     pageHeader(pageNum) {
-      return this.navigation[pageNum - 1].name;
+      return get(this.navigation, `[${pageNum - 1}].name`, '');
     },
     pageSubheader(pageNum) {
-      return this.navigation[pageNum] ? this.pageHeader(pageNum + 1) : '';
+      return get(this.navigation, `[${pageNum}]`, null)
+        ? this.pageHeader(pageNum + 1)
+        : '';
     }
   },
   computed: {

--- a/src/components/pmu/PmuPreSignPreview.vue
+++ b/src/components/pmu/PmuPreSignPreview.vue
@@ -27,12 +27,16 @@ export default {
   methods: {
     ...mapActions('client', ['pmuPreSignPreview']),
     async _pmuPreSignPreview() {
-      this.imagePreview = await this.pmuPreSignPreview({
-        params: {
-          clientId: this.clientId,
-          tenantSlug: this.tenantSlug
-        }
-      });
+      try {
+        this.imagePreview = await this.pmuPreSignPreview({
+          params: {
+            clientId: this.clientId,
+            tenantSlug: this.tenantSlug
+          }
+        });
+      } catch (error) {
+        this.$emit('errorAlreadySigned');
+      }
     },
     init() {
       this._pmuPreSignPreview();

--- a/src/router/clientRoutes.js
+++ b/src/router/clientRoutes.js
@@ -112,6 +112,18 @@ export const clientRoutes = [
         }
       },
       {
+        path: 'pmu-sign/guest-result',
+        name: 'PmuSignGuestResult',
+        component: () => import('@/views/PmuSign.vue'),
+        props: true,
+        meta: {
+          noNavigation: true,
+          layout: WithTitleBarLayout,
+          title: 'PMU Form Sign',
+          backRoute: { name: 'ClientEdit' }
+        }
+      },
+      {
         path: 'pmu-sign-from-notify',
         name: 'PmuSignFromNotify',
         component: () => import('@/views/PmuSignFlow.vue'),


### PR DESCRIPTION
# Issue Being Addressed

#185 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[x] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?
Prevent double rendering of sign-flow component (causes fetching preview two times which is a heavy API request) [WIP]

**For Feature Updates:** What feature are we updating? Explain your technical approach to doing this.  
Redirect to PMU result page if user has already signed the PMU  
Hide bottom navigation when user opens link from SMS [WIP]  

