### PR TITLE
PMU - add download page by sms

### DIFF
--- a/src/router/clientRoutes.js
+++ b/src/router/clientRoutes.js
@@ -44,9 +44,8 @@ export const clientRoutes = [
     name: 'Client',
     props: true,
     component: () => import('@/views/Client.vue'),
+    redirect: { name: 'ClientEdit' },
     meta: {
-      // TODO: remove layout line, has no effect on pages
-      layout: WithTitleBarLayout,
       title: 'Client Profile',
       backRoute: { name: 'ClientList' }
     },
@@ -120,7 +119,17 @@ export const clientRoutes = [
           backRoute: { name: 'ClientEdit' }
         }
       },
-
+      {
+        path: 'pmu-form-download/:templateId',
+        name: 'PmuFormDownload',
+        component: () => import('@/views/PmuFormDownload.vue'),
+        props: true,
+        meta: {
+          noNavigation: true,
+          layout: WithTitleBarLayout,
+          title: 'PMU Form Download'
+        }
+      },
       // flow (From Notification)
       {
         path: 'pmu-sign-fn/:templateId/flow',

--- a/src/services/pmu.js
+++ b/src/services/pmu.js
@@ -107,8 +107,9 @@ export const adaptApiQuestionsToModel = questions => {
   });
 };
 
-export const adaptAnswersToApi = questionList => {
+export const adaptAnswersToApi = (questionList, callbackUrl) => {
   return {
+    notificationCallBackUrl: callbackUrl,
     answers: questionList.map(question => {
       return {
         formItemId: question.questionId,

--- a/src/views/PmuFormDownload.vue
+++ b/src/views/PmuFormDownload.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="max-w-4xl mx-auto px-4 pt-4">
+    <div class="text-left p-2 text-on-background" v-if="client">
+      <h2 class="tg-body-mobile py-2 text-center my-6 text-on-background">
+        Signed PMU form for {{ client.firstName + ' ' + client.lastName }}
+      </h2>
+      <Button
+        :href="pdfUrl"
+        class="rounded-full mb-6 "
+        title="Download Signed PMU"
+      ></Button>
+
+      <div class="text-center">
+        <Button :to="{ name: 'Home' }" title="Go Home Page" theme="none" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapMutations } from 'vuex';
+import Button from '@/components/inputs/Button.vue';
+
+export default {
+  name: 'PmuFormDownload',
+  components: {
+    Button
+  },
+  props: ['tenantSlug', 'clientId', 'templateId'],
+  created() {
+    this.init();
+  },
+  data: () => ({
+    client: null
+  }),
+  computed: {
+    pdfUrl() {
+      if (!this.client) {
+        return undefined;
+      }
+      const signature = this.client.signatures.find(
+        sig => sig.formTemplateId === Number(this.templateId)
+      );
+      return signature && signature.pdfUrl;
+    }
+  },
+  methods: {
+    ...mapMutations('loading', ['loading']),
+    ...mapActions('client', [
+      'fetchClient',
+      'pmuSendFormLink',
+      'pmuEmptyPreview'
+    ]),
+    ...mapActions('formTemplate', ['templatesFetch']),
+    init() {
+      this._fetchClient();
+    },
+    async _fetchClient() {
+      this.loading(true);
+
+      this.client = await this.fetchClient({
+        params: {
+          clientId: this.clientId,
+          tenantSlug: this.tenantSlug
+        }
+      }).catch(() => {
+        alert('Error in getting client');
+      });
+
+      this.loading(false);
+    }
+  }
+};
+</script>

--- a/src/views/PmuSignFlow.vue
+++ b/src/views/PmuSignFlow.vue
@@ -8,8 +8,24 @@
       rel="stylesheet"
       href="https://unpkg.com/@ditdot-dev/vue-flow-form@1.1.0/dist/vue-flow-form.theme-minimal.min.css"
     />
+    <div
+      class="px-4 max-w-md mx-auto h-vh100 flex items-center justify-center"
+      v-if="isReady && !(questions.length > 0)"
+    >
+      <BaseCard>
+        <div class="flex flex-col">
+          <p class="text-error tg-h3-mobile mb-6">
+            This form template has no questions.
+          </p>
+
+          <div class="text-center">
+            <Button :to="{ name: 'Home' }" title="Go home page" theme="none" />
+          </div>
+        </div>
+      </BaseCard>
+    </div>
     <FlowForm
-      v-if="isReady"
+      v-else-if="isReady"
       v-on:submit="onSubmit"
       v-on:complete="onComplete"
       v-bind:questions="questions"
@@ -54,6 +70,8 @@ import { mapActions } from 'vuex';
 import { adaptApiQuestionsToModel, adaptAnswersToApi } from '@/services/pmu.js';
 import { get } from 'lodash-es';
 import PmuFormFilledPreview from '@/components/pmu/PmuFormFilledPreview.vue';
+import BaseCard from '@/components/BaseCard.vue';
+import Button from '@/components/inputs/Button.vue';
 
 // https://github.com/ditdot-dev/vue-flow-form
 
@@ -61,6 +79,8 @@ export default {
   name: 'example',
   props: ['tenantSlug', 'clientId', 'templateId'],
   components: {
+    Button,
+    BaseCard,
     FlowForm,
     PmuFormFilledPreview
   },
@@ -101,7 +121,13 @@ export default {
     onSubmit(questionList) {
       // This method will only be called if you don't override the
       // completeButton slot.
-      const payload = adaptAnswersToApi(questionList);
+
+      const path = this.$router.resolve({
+        name: 'PmuFormDownload'
+      }).href;
+      const callbackUrl = `${window.location.origin}${path}`;
+      console.log('notificationCallBackUrl', callbackUrl);
+      const payload = adaptAnswersToApi(questionList, callbackUrl);
 
       console.log('answers for api:', payload);
       this.pmuSignSubmitAnswers({


### PR DESCRIPTION
# Issue Being Addressed

#291 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[ ] Bug Fix
[ ] Refactor
[x] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For New Features:**  
Download PDF link from google apis was ugly and long, so I created a page to download the file inside the app without login (login by token in URL)

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.

Sign a new PMU and open the result link inside SMS.

# Screenshots/casts

![localhost_8080_tenant_asdf-122_clients_124_pmu-form-download_11](https://user-images.githubusercontent.com/510242/93485528-678c4a00-f918-11ea-99fc-2ba519617360.png)
