### PR TITLE
Remove form input trailing spaces

### DIFF
--- a/src/components/client/BasicInfo.vue
+++ b/src/components/client/BasicInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="px-6 pb-20">
     <MaterialInput
-      v-model="$v.firstName.$model"
+      v-model.trim="$v.firstName.$model"
       label="First Name"
       :error="$v.firstName.$error"
       theme="light"
@@ -11,7 +11,7 @@
       </p>
     </MaterialInput>
     <MaterialInput
-      v-model="$v.lastName.$model"
+      v-model.trim="$v.lastName.$model"
       label="Last Name"
       :error="$v.lastName.$error"
       theme="light"
@@ -21,7 +21,7 @@
       </p>
     </MaterialInput>
     <MaterialInput
-      v-model="$v.phone.$model"
+      v-model.trim="$v.phone.$model"
       label="Phone number"
       :error="$v.phone.$error"
       theme="light"
@@ -34,7 +34,7 @@
       </p>
     </MaterialInput>
     <MaterialInput
-      v-model="$v.email.$model"
+      v-model.trim="$v.email.$model"
       label="Email"
       :error="$v.email.$error"
       theme="light"

--- a/src/components/inputs/MaterialInput.vue
+++ b/src/components/inputs/MaterialInput.vue
@@ -13,7 +13,7 @@
       :type="type"
       :min="min"
       :step="step"
-      :value="value"
+      :value="value | trim"
       v-on="inputListeners"
       :placeholder="placeholder || label"
     />
@@ -83,6 +83,11 @@ export default {
     immediateInput: {
       type: Boolean,
       default: false
+    }
+  },
+  filters: {
+    trim: function(value) {
+      return value.trim();
     }
   },
   computed: {

--- a/src/components/tenant/BusinessInfo.vue
+++ b/src/components/tenant/BusinessInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="px-6 pb-20 pt-6">
     <MaterialInput
-      v-model="$v.name.$model"
+      v-model.trim="$v.name.$model"
       label="Name"
       :error="$v.name.$error"
     >
@@ -10,7 +10,7 @@
       </span>
     </MaterialInput>
     <MaterialInput
-      v-model="$v.phone.$model"
+      v-model.trim="$v.phone.$model"
       label="Phone number"
       :error="$v.phone.$error"
     >

--- a/src/views/AuthLogin.vue
+++ b/src/views/AuthLogin.vue
@@ -23,7 +23,7 @@
       >
         <div class="">
           <MaterialInput
-            v-model="$v.email.$model"
+            v-model.trim="$v.email.$model"
             label="Email"
             :error="$v.email.$error"
             theme="light"
@@ -38,7 +38,7 @@
 
           <MaterialInput
             type="password"
-            v-model="$v.password.$model"
+            v-model.trim="$v.password.$model"
             label="Password"
             :error="$v.password.$error"
           >

--- a/src/views/AuthSignup.vue
+++ b/src/views/AuthSignup.vue
@@ -33,7 +33,7 @@
             </p>
           </MaterialInput>
           <MaterialInput
-            v-model="$v.email.$model"
+            v-model.trim="$v.email.$model"
             label="Email Address"
             :error="$v.email.$error"
           >

--- a/src/views/AuthSignup.vue
+++ b/src/views/AuthSignup.vue
@@ -15,7 +15,7 @@
       >
         <div class="">
           <MaterialInput
-            v-model="$v.firstName.$model"
+            v-model.trim="$v.firstName.$model"
             label="First Name"
             :error="$v.firstName.$error"
           >
@@ -24,7 +24,7 @@
             </p>
           </MaterialInput>
           <MaterialInput
-            v-model="$v.lastName.$model"
+            v-model.trim="$v.lastName.$model"
             label="Last Name"
             :error="$v.lastName.$error"
           >
@@ -46,7 +46,7 @@
           </MaterialInput>
           <MaterialInput
             type="password"
-            v-model="$v.password.$model"
+            v-model.trim="$v.password.$model"
             label="Password"
             :error="$v.password.$error"
           >

--- a/src/views/ClientInfoEdit.vue
+++ b/src/views/ClientInfoEdit.vue
@@ -2,7 +2,7 @@
   <div class="shadow-1dp px-2 py-6 rounded-lg mb-4 bg-surface">
     <MaterialInput
       margin="mb-6"
-      v-model="$v.client.firstName.$model"
+      v-model.trim="$v.client.firstName.$model"
       label="First Name"
       :error="$v.client.firstName.$error"
     >
@@ -12,7 +12,7 @@
     </MaterialInput>
     <MaterialInput
       margin="mb-6"
-      v-model="$v.client.lastName.$model"
+      v-model.trim="$v.client.lastName.$model"
       label="Last Name"
       :error="$v.client.lastName.$error"
     >
@@ -22,7 +22,7 @@
     </MaterialInput>
     <MaterialInput
       margin="mb-6"
-      v-model="$v.client.phoneNumber.$model"
+      v-model.trim="$v.client.phoneNumber.$model"
       label="Phone Number"
       :error="$v.client.phoneNumber.$error"
     >
@@ -40,7 +40,7 @@
     </MaterialInput>
     <MaterialInput
       :margin="null"
-      v-model="$v.client.email.$model"
+      v-model.trim="$v.client.email.$model"
       label="Email"
       :error="$v.client.email.$error"
       :attrs="{ readonly: true }"

--- a/src/views/FormTemplateItemEditMeta.vue
+++ b/src/views/FormTemplateItemEditMeta.vue
@@ -10,7 +10,7 @@
     </div>
     <MaterialInput
       margin="mb-6"
-      v-model="$v.name.$model"
+      v-model.trim="$v.name.$model"
       label="Name"
       placeholder="e.g. PMU Agreement Form"
       :error="$v.name.$error"


### PR DESCRIPTION
# Issue Being Addressed

Put the issue(s) # that your PR is addressing here. e.g. `#15`, `#29`

Closes #298 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?

- Initially, there wasn't anything being done to remove the trailing whitespace from form inputs.
- These commits fix the bug by:
   - Adding a trim filter to the `MaterialInput` component.
  - Updating views that use `MaterialInput` so that the modal attribute on them also includes the "trim" modifier.


# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Click on 'Create an account'
2. Fill in each form input while including whitespace at the beginning of the value you entered
3. Focus away from an input
4. Focus on the input again. You'll see that all the trailing whitespace has been removed

**Note**: If form validation fails for an input, the whitespace may not be removed right away, however, if you submit the form after fixing the validation errors, the submitted values will have trailing whitespace removed from them.