### PR TITLE
371 form-template - change pdf/image field default description

### DIFF
--- a/src/components/formTemplate/FormTemplateFieldUpload.vue
+++ b/src/components/formTemplate/FormTemplateFieldUpload.vue
@@ -38,12 +38,12 @@
     </div>
 
     <div class="px-4">
-      <CheckBox
+      <!-- <CheckBox
         class="block mb-8"
         v-model="model.isRequired"
         :value="true"
         label="This question is required"
-      />
+      /> -->
 
       <Button class="rounded-full mb-4" title="Save" @clicked="save" />
 
@@ -67,6 +67,8 @@ import { required } from 'vuelidate/lib/validators';
 import { mapActions, mapGetters } from 'vuex';
 import { getCloudinaryThumbnail, randomId } from '@/helpers.js';
 
+const isRequiredAlwaysTrue = true;
+
 export default {
   name: 'FormTemplateFieldUpload',
   components: {
@@ -88,7 +90,8 @@ export default {
     file: null,
     model: {
       options: [],
-      isRequired: false,
+      // NOTE: always required
+      isRequired: isRequiredAlwaysTrue,
       value: ''
     }
   }),
@@ -96,7 +99,11 @@ export default {
     ...mapGetters('uploader', ['uploadedFilesGet'])
   },
   created() {
-    this.model = { ...this.model, ...cloneDeep(this.initialModel) };
+    this.model = {
+      ...this.model,
+      ...cloneDeep(this.initialModel),
+      isRequired: isRequiredAlwaysTrue
+    };
     if (this.model.draft) {
       this.checkUploadedFileExistance();
       this.openDrawerUploadUpdate(false);

--- a/src/views/FormTemplateFieldSelection.vue
+++ b/src/views/FormTemplateFieldSelection.vue
@@ -66,7 +66,8 @@ export default {
         // NOTE: we'll set the actual type in FormTemplateDrawerUpload after upload file (image or pdf)
         type: 'upload',
         description:
-          'Already have a PDF or JPEF of your form? Upload to your template with an agreement request.'
+          'Already have a PDF or JPEF of your form? Upload to your template with an agreement request.',
+        value: 'I agree to all terms and conditions above.'
       };
     },
     fieldsAvailable() {


### PR DESCRIPTION
# Issues Being Addressed

#371 

Put the issue(s) # that your PR is addressing here. e.g. `#15`, `#29`

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?  
- Set default description for image and PDF field in form template builder
- Remove requirement checkbox (always true)