### PR TITLE
370 Add preview to form template builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "core-js": "^3.6.4",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.0.10",
+    "downloadjs": "^1.4.7",
     "keen-slider": "^5.1.0",
     "lodash-es": "^4.17.15",
     "portal-vue": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@whynotearth/meredith-axios": "^1.0.58",
+    "@whynotearth/meredith-axios": "^1.0.59",
     "@whynotearth/vue-flow-form": "^0.0.2",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",

--- a/src/assets/styles/colors.js
+++ b/src/assets/styles/colors.js
@@ -15,6 +15,7 @@ const colors = {
   'on-secondary': '#78839C',
   'on-surface': '#0D1F3C',
   'on-background': '#000000',
+  'on-background-image': '#ffffff',
   'on-error': '#FFFFFF',
   'on-accent': '#FFFFFF',
   brand1: '#B5BBC9',

--- a/src/components/formTemplate/FormTemplatePreviewModal.vue
+++ b/src/components/formTemplate/FormTemplatePreviewModal.vue
@@ -6,19 +6,6 @@
       class="flex flex-col items-center text-left w-full h-full relative"
       @click="closeModal"
     >
-      <!-- caption -->
-      <div
-        @click.stop=""
-        class="absolute bottom-0 w-full content-gradient pb-14"
-      >
-        <div class="py-10 px-4 text-on-background-image text-opacity-high">
-          <h1 class="tg-body-mobile mb-2">
-            {{ currentTemplateGet.name }}
-          </h1>
-          <p class="tg-caption-mobile">{{ createdAt }}</p>
-        </div>
-      </div>
-
       <!-- top toolbar -->
       <div class="flex justify-start w-full flex-shrink-0">
         <button class="p-3" @click.prevent="closeModal" title="Close">
@@ -38,20 +25,29 @@
         /> -->
       </div>
 
-      <!-- bottom toolbar -->
+      <!-- caption -->
       <div
-        class="flex justify-end w-full flex-shrink-0 z-50 relative"
         @click.stop=""
+        class="w-full content-gradient pb-14 absolute bottom-0"
       >
+        <div class="py-10 px-4 text-on-background-image text-opacity-high">
+          <h1 class="tg-body-mobile mb-2">
+            {{ currentTemplateGet.name }}
+          </h1>
+          <p class="tg-caption-mobile">{{ createdAt }}</p>
+        </div>
+      </div>
+
+      <!-- bottom toolbar -->
+      <div class="flex justify-end w-full z-20" @click.stop="">
         <div class="flex flex-col justify-center w-full">
-          <div class="cta-wrapper relative z-50">
+          <div class="cta-wrapper">
             <Button
               title="Preview"
               class="uppercase"
               background="bg-primary"
               textColor="text-on-primary"
-              @clicked="tellmeee"
-              :to="{ name: 'PmuSignFlowPreview' }"
+              @clicked="previewFlow"
             />
           </div>
         </div>
@@ -124,8 +120,8 @@ export default {
     }
   },
   methods: {
-    tellmeee() {
-      console.log('hii');
+    previewFlow() {
+      this.$router.push({ name: 'PmuSignFlowMock' });
     },
     shareDataUrl,
     isShareApiSupported,
@@ -153,6 +149,5 @@ export default {
 }
 .cta-wrapper {
   transform: translateY(-50%);
-  pointer-events: none;
 }
 </style>

--- a/src/components/formTemplate/FormTemplatePreviewModal.vue
+++ b/src/components/formTemplate/FormTemplatePreviewModal.vue
@@ -6,23 +6,16 @@
       class="flex flex-col items-center text-left w-full h-full relative"
       @click="closeModal"
     >
+      <!-- caption -->
       <div
-        class="absolute bottom-0 w-full flex flex-col justify-center content-gradient pb-14"
+        @click.stop=""
+        class="absolute bottom-0 w-full content-gradient pb-14"
       >
-        <div class="pt-10 px-4 text-on-background-image text-opacity-high">
+        <div class="py-10 px-4 text-on-background-image text-opacity-high">
           <h1 class="tg-body-mobile mb-2">
             {{ currentTemplateGet.name }}
           </h1>
           <p class="tg-caption-mobile">{{ createdAt }}</p>
-        </div>
-
-        <div class="cta-wrapper relative">
-          <Button
-            title="Send me a test"
-            class="uppercase"
-            background="bg-primary"
-            textColor="text-on-primary"
-          />
         </div>
       </div>
 
@@ -34,26 +27,49 @@
       </div>
 
       <!-- content -->
-      <div class="w-full my-auto overflow-y-auto bg-white flex-grow">
-        <PmuFormEmptyPreview
+      <div
+        class="w-full my-auto overflow-y-auto bg-white flex-grow"
+        @click.stop=""
+      >
+        <!-- <PmuFormEmptyPreview
           @imageReady="onImagePreviewReady"
           :tenantSlug="tenantSlug"
           :templateId="templateId"
-        />
+        /> -->
       </div>
 
       <!-- bottom toolbar -->
-      <div class="flex justify-end w-full flex-shrink-0 z-10">
+      <div
+        class="flex justify-end w-full flex-shrink-0 z-50 relative"
+        @click.stop=""
+      >
+        <div class="flex flex-col justify-center w-full">
+          <div class="cta-wrapper relative z-50">
+            <Button
+              title="Preview"
+              class="uppercase"
+              background="bg-primary"
+              textColor="text-on-primary"
+              @clicked="tellmeee"
+              :to="{ name: 'PmuSignFlowPreview' }"
+            />
+          </div>
+        </div>
+
         <!-- share -->
-        <!-- TODO: -->
-        <!-- <a
-          v-if="isShareApiSupported"
-          @click.stop="share({ url: pdfUrl })"
+        <a
+          v-if="isShareApiSupported()"
+          @click.stop="
+            shareDataUrl({
+              data: imagePreviewBase64,
+              filename: previewFileName
+            })
+          "
           class="cursor-pointer p-4"
           title="Share"
         >
           <ShareIcon class="text-white w-6 h-6" />
-        </a> -->
+        </a>
 
         <!-- download -->
         <a
@@ -74,9 +90,9 @@ import DeleteIcon from '@/assets/icons/delete.svg';
 import DownloadIcon from '@/assets/icons/download.svg';
 import ShareIcon from '@/assets/icons/share.svg';
 import {
-  transformCloudinaryUrl,
+  isShareApiSupported,
   urlToFile,
-  share,
+  shareDataUrl,
   formatDateTime
 } from '@/helpers.js';
 import noPageScrollbarMixin from '@/utils/noPageScrollbarMixin.js';
@@ -100,26 +116,22 @@ export default {
   },
   computed: {
     ...mapGetters('formTemplate', ['currentTemplateGet']),
-    isShareApiSupported() {
-      return !!window.navigator.share;
-    },
     createdAt() {
       return formatDateTime(this.currentTemplateGet.createdAt);
+    },
+    previewFileName() {
+      return `${this.currentTemplateGet.name}.jpg`;
     }
   },
-  created() {
-    console.log('currentTemplateGet', this.currentTemplateGet);
-  },
   methods: {
-    transformCloudinaryUrl,
+    tellmeee() {
+      console.log('hii');
+    },
+    shareDataUrl,
+    isShareApiSupported,
     urlToFile,
-    share,
     downloadFile() {
-      downloadjs(
-        this.imagePreviewBase64,
-        `${this.currentTemplateGet.name}.jpg`,
-        'image/jpg'
-      );
+      downloadjs(this.imagePreviewBase64, this.previewFileName, 'image/jpg');
     },
     onImagePreviewReady(imagePreviewBase64) {
       this.imagePreviewBase64 = imagePreviewBase64;
@@ -140,6 +152,7 @@ export default {
   background: linear-gradient(180deg, transparent 0%, #000000 93.85%);
 }
 .cta-wrapper {
-  transform: translateY(50%);
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 </style>

--- a/src/components/formTemplate/FormTemplatePreviewModal.vue
+++ b/src/components/formTemplate/FormTemplatePreviewModal.vue
@@ -1,0 +1,145 @@
+<template>
+  <div
+    class="h-vh100 bg-black bg-opacity-high z-50 fixed w-screen top-0 left-0 flex justify-center items-center"
+  >
+    <div
+      class="flex flex-col items-center text-left w-full h-full relative"
+      @click="closeModal"
+    >
+      <div
+        class="absolute bottom-0 w-full flex flex-col justify-center content-gradient pb-14"
+      >
+        <div class="pt-10 px-4 text-on-background-image text-opacity-high">
+          <h1 class="tg-body-mobile mb-2">
+            {{ currentTemplateGet.name }}
+          </h1>
+          <p class="tg-caption-mobile">{{ createdAt }}</p>
+        </div>
+
+        <div class="cta-wrapper relative">
+          <Button
+            title="Send me a test"
+            class="uppercase"
+            background="bg-primary"
+            textColor="text-on-primary"
+          />
+        </div>
+      </div>
+
+      <!-- top toolbar -->
+      <div class="flex justify-start w-full flex-shrink-0">
+        <button class="p-3" @click.prevent="closeModal" title="Close">
+          <Close class="text-white" />
+        </button>
+      </div>
+
+      <!-- content -->
+      <div class="w-full my-auto overflow-y-auto bg-white flex-grow">
+        <PmuFormEmptyPreview
+          @imageReady="onImagePreviewReady"
+          :tenantSlug="tenantSlug"
+          :templateId="templateId"
+        />
+      </div>
+
+      <!-- bottom toolbar -->
+      <div class="flex justify-end w-full flex-shrink-0 z-10">
+        <!-- share -->
+        <!-- TODO: -->
+        <!-- <a
+          v-if="isShareApiSupported"
+          @click.stop="share({ url: pdfUrl })"
+          class="cursor-pointer p-4"
+          title="Share"
+        >
+          <ShareIcon class="text-white w-6 h-6" />
+        </a> -->
+
+        <!-- download -->
+        <a
+          @click.stop="downloadFile"
+          class="cursor-pointer p-4"
+          title="Download"
+        >
+          <DownloadIcon class="text-white w-6 h-6" />
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Close from '@/assets/icons/close.svg';
+import DeleteIcon from '@/assets/icons/delete.svg';
+import DownloadIcon from '@/assets/icons/download.svg';
+import ShareIcon from '@/assets/icons/share.svg';
+import {
+  transformCloudinaryUrl,
+  urlToFile,
+  share,
+  formatDateTime
+} from '@/helpers.js';
+import noPageScrollbarMixin from '@/utils/noPageScrollbarMixin.js';
+import { mapGetters } from 'vuex';
+import PmuFormEmptyPreview from '@/components/pmu/PmuFormEmptyPreview.vue';
+import downloadjs from 'downloadjs';
+
+export default {
+  name: 'FormTemplatePreviewModal',
+  data: () => ({
+    imagePreviewBase64: ''
+  }),
+  mixins: [noPageScrollbarMixin],
+  props: ['tenantSlug', 'templateId'],
+  components: {
+    Close,
+    DeleteIcon,
+    DownloadIcon,
+    ShareIcon,
+    PmuFormEmptyPreview
+  },
+  computed: {
+    ...mapGetters('formTemplate', ['currentTemplateGet']),
+    isShareApiSupported() {
+      return !!window.navigator.share;
+    },
+    createdAt() {
+      return formatDateTime(this.currentTemplateGet.createdAt);
+    }
+  },
+  created() {
+    console.log('currentTemplateGet', this.currentTemplateGet);
+  },
+  methods: {
+    transformCloudinaryUrl,
+    urlToFile,
+    share,
+    downloadFile() {
+      downloadjs(
+        this.imagePreviewBase64,
+        `${this.currentTemplateGet.name}.jpg`,
+        'image/jpg'
+      );
+    },
+    onImagePreviewReady(imagePreviewBase64) {
+      this.imagePreviewBase64 = imagePreviewBase64;
+    },
+    closeModal() {
+      this.$emit('close');
+    },
+    remove() {
+      this.$emit('remove', this.file);
+      this.closeModal();
+    }
+  }
+};
+</script>
+
+<style scoped>
+.content-gradient {
+  background: linear-gradient(180deg, transparent 0%, #000000 93.85%);
+}
+.cta-wrapper {
+  transform: translateY(50%);
+}
+</style>

--- a/src/components/pmu/PmuFormEmptyPreview.vue
+++ b/src/components/pmu/PmuFormEmptyPreview.vue
@@ -22,18 +22,20 @@ export default {
     imagePreview: ''
   }),
   created() {
-    this._pmuEmptyPreview();
+    this._pmuEmptyPngPreview();
   },
   methods: {
-    ...mapActions('client', ['pmuEmptyPreview']),
-    async _pmuEmptyPreview() {
-      this.imagePreview = await this.pmuEmptyPreview({
+    ...mapActions('client', ['pmuEmptyPngPreview']),
+    async _pmuEmptyPngPreview() {
+      this.imagePreview = await this.pmuEmptyPngPreview({
         params: {
           tenantSlug: this.tenantSlug,
           templateId: this.templateId
         }
+      }).catch(error => {
+        console.log(error);
+        alert('Something went wrong in generating image preview');
       });
-      this.$emit('imageReady', this.imagePreview);
     }
   }
 };

--- a/src/components/pmu/PmuFormEmptyPreview.vue
+++ b/src/components/pmu/PmuFormEmptyPreview.vue
@@ -33,9 +33,7 @@ export default {
           templateId: this.templateId
         }
       });
-    },
-    init() {
-      this._pmuEmptyPreview();
+      this.$emit('imageReady', this.imagePreview);
     }
   }
 };

--- a/src/components/pmu/PmuFormFilledPreview.vue
+++ b/src/components/pmu/PmuFormFilledPreview.vue
@@ -17,7 +17,17 @@
 import { mapActions } from 'vuex';
 export default {
   name: 'PmuFormFilledPreview',
-  props: ['tenantSlug', 'templateId', 'title', 'clientId', 'answers'],
+  props: {
+    tenantSlug: [Number, String],
+    templateId: [Number, String],
+    title: String,
+    clientId: [Number, String],
+    answers: Object,
+    isMock: {
+      type: Boolean,
+      default: false
+    }
+  },
   data: () => ({
     imagePreview: ''
   }),
@@ -26,8 +36,13 @@ export default {
   },
   methods: {
     ...mapActions('client', ['pmuFilledPreview']),
+    ...mapActions('tenant', ['pmuFilledPreviewMock']),
     async _pmuFilledPreview() {
-      this.imagePreview = await this.pmuFilledPreview({
+      const method = this.isMock
+        ? this.pmuFilledPreviewMock
+        : this.pmuFilledPreview;
+
+      this.imagePreview = await method({
         params: {
           tenantSlug: this.tenantSlug,
           templateId: this.templateId,

--- a/src/components/uploader/ImagePreviewModal.vue
+++ b/src/components/uploader/ImagePreviewModal.vue
@@ -41,7 +41,7 @@
           @click.stop=""
           :href="transformCloudinaryUrl(file.url, 'fl_attachment')"
           class="cursor-pointer p-4"
-          title="Download (Save the file in new tab)"
+          title="Download"
         >
           <DownloadIcon class="text-white w-6 h-6" />
         </a>

--- a/src/components/uploader/VideoPreviewModal.vue
+++ b/src/components/uploader/VideoPreviewModal.vue
@@ -37,7 +37,7 @@
           @click.stop=""
           :href="transformCloudinaryUrl(file.url, 'fl_attachment')"
           class="cursor-pointer p-4"
-          title="Download (Save the file in new tab)"
+          title="Download"
         >
           <DownloadIcon class="text-white w-6 h-6" />
         </a>

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -149,8 +149,31 @@ export function urlToFile(jsonfile) {
   });
 }
 
+// https://stackoverflow.com/a/38935990
+function dataUrltoFile(dataurl, filename) {
+  var arr = dataurl.split(','),
+    mime = arr[0].match(/:(.*?);/)[1],
+    bstr = atob(arr[1]),
+    n = bstr.length,
+    u8arr = new Uint8Array(n);
+
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+
+  return new File([u8arr], filename, { type: mime });
+}
+
 export function isShareApiSupported() {
   return !!window.navigator.share;
+}
+
+// no old share
+export function shareDataUrl({ data, filename }) {
+  const file = dataUrltoFile(data, filename);
+  window.navigator.share({
+    files: [file]
+  });
 }
 
 // @input jsonfile: {url}
@@ -161,7 +184,7 @@ export function share(jsonfile) {
     return;
   }
 
-  this.urlToFile(jsonfile).then(file => {
+  urlToFile(jsonfile).then(file => {
     // https://web.dev/web-share/#sharing-files
     window.navigator
       .share({

--- a/src/router/clientRoutes.js
+++ b/src/router/clientRoutes.js
@@ -101,7 +101,7 @@ export const clientRoutes = [
           appBar: { layout: AppBarLayout, title: 'PMU Form Download' }
         }
       },
-      // flow (From Notification)
+      // question flow (From Notification)
       {
         path: 'pmu-sign-fn/:templateId/flow',
         name: 'PmuSignFromNotify',
@@ -112,8 +112,8 @@ export const clientRoutes = [
           appBar: { title: 'PMU Form Sign', backRoute: { name: 'ClientInfo' } }
         }
       },
+      // question flow (No SMS)
       {
-        // flow (No SMS)
         path: 'pmu-sign/:templateId/flow',
         name: 'PmuSignFlow',
         component: () => import('@/views/PmuSignFlow.vue'),

--- a/src/router/formTemplateRoutes.js
+++ b/src/router/formTemplateRoutes.js
@@ -115,9 +115,9 @@ export const formTemplateRoutes = [
 
           // flow (For tenant testing and preview)
           {
-            path: 'flow-preview',
-            name: 'PmuSignFlowPreview',
-            component: () => import('@/views/PmuSignFlowPreview.vue'),
+            path: 'flow-mock',
+            name: 'PmuSignFlowMock',
+            component: () => import('@/views/PmuSignFlowMock.vue'),
             props: true
           }
         ]

--- a/src/router/formTemplateRoutes.js
+++ b/src/router/formTemplateRoutes.js
@@ -111,6 +111,14 @@ export const formTemplateRoutes = [
                 backRoute: { name: 'FormTemplateItemEdit' }
               }
             }
+          },
+
+          // flow (For tenant testing and preview)
+          {
+            path: 'flow-preview',
+            name: 'PmuSignFlowPreview',
+            component: () => import('@/views/PmuSignFlowPreview.vue'),
+            props: true
           }
         ]
       }

--- a/src/store/modules/client.js
+++ b/src/store/modules/client.js
@@ -100,9 +100,9 @@ const actions = {
   pmuSendFormLink(context, { params }) {
     return FormAnswerService.notify(params);
   },
-  pmuEmptyPreview(context, { params }) {
+  pmuEmptyPngPreview(context, { params }) {
     // NOTE: this is equal to tenant/pmuEmptyPreview
-    return FormAnswerService.preview(params);
+    return FormAnswerService.png(params);
   },
   pmuFilledPreview(context, { params }) {
     return FormAnswerService.preview1(params);

--- a/src/store/modules/tenant.js
+++ b/src/store/modules/tenant.js
@@ -9,8 +9,17 @@ const getters = {};
 const mutations = {};
 
 const actions = {
-  pmuEmptyPreview(context, { params }) {
+  pmuEmptyPdfPreview(context, { params }) {
+    return FormAnswerService.pdf(params);
+  },
+  pmuEmptyPngPreview(context, { params }) {
     // NOTE: this is equal to clinet/pmuEmptyPreview
+    return FormAnswerService.png(params);
+  },
+
+  // without clientId
+  pmuFilledPreviewMock(context, { params }) {
+    console.log('params', params);
     return FormAnswerService.preview(params);
   },
 

--- a/src/views/FormTemplateItemEdit.vue
+++ b/src/views/FormTemplateItemEdit.vue
@@ -28,6 +28,13 @@
     </router-link>
 
     <div class="px-4 md:px-0">
+      <Button
+        type="button"
+        class="uppercase mb-6"
+        @clicked="isPreviewModalOpen = true"
+        title="Preview & Test"
+      />
+
       <!-- current questions -->
       <SortableList
         :useWindowAsScrollContainer="true"
@@ -122,11 +129,19 @@
         :margin="null"
       />
     </BaseDialog>
+
+    <FormTemplatePreviewModal
+      v-if="isPreviewModalOpen"
+      @close="isPreviewModalOpen = false"
+      :tenantSlug="tenantSlug"
+      :templateId="templateId"
+    />
   </div>
 </template>
 
 <script>
 import FormTemplateFieldTypeCard from '@/components/formTemplate/FormTemplateFieldTypeCard';
+import FormTemplatePreviewModal from '@/components/formTemplate/FormTemplatePreviewModal';
 import IconArrowRight from '@/assets/icons/keyboard_arrow_right.svg';
 import BaseCard from '@/components/BaseCard';
 import BaseDialog from '@/components/BaseDialog';
@@ -172,6 +187,7 @@ export default {
   mixins: [noPullToRefresh],
   props: ['tenantSlug'],
   components: {
+    FormTemplatePreviewModal,
     BaseDialog,
     SortableList,
     SortableItem,
@@ -181,10 +197,14 @@ export default {
     IconAdd
   },
   data: () => ({
+    isPreviewModalOpen: false,
     isDeleteModalOpen: false
   }),
   computed: {
-    ...mapGetters('formTemplate', ['currentTemplateGet'])
+    ...mapGetters('formTemplate', ['currentTemplateGet']),
+    templateId() {
+      return this.$route.params.formId;
+    }
   },
   async created() {
     this.loadingUpdate(true);
@@ -205,7 +225,7 @@ export default {
       if (this.currentTemplateGet.draft && !this.$route.query.refresh) {
         return;
       }
-      if (!this.$route.params.formId) {
+      if (!this.templateId) {
         throw new Error('Something went wrong');
       }
 
@@ -214,7 +234,7 @@ export default {
     _templateFetch() {
       return this.templateFetch({
         params: {
-          templateId: this.$route.params.formId,
+          templateId: this.templateId,
           tenantSlug: this.tenantSlug
         }
       }).catch(() => {
@@ -238,8 +258,8 @@ export default {
       this.templateDelete({
         isDraft: this.currentTemplateGet.draft,
         params: {
-          tenantSlug: this.tenantSlug,
-          templateId: this.$route.params.formId
+          templateId: this.templateId,
+          tenantSlug: this.tenantSlug
         }
       })
         .then(async () => {

--- a/src/views/PmuSignFlow.vue
+++ b/src/views/PmuSignFlow.vue
@@ -25,15 +25,15 @@
             {{ errorMessage }}
           </ErrorFullScreen>
           <div v-else-if="isSubmitted">
-            <p class="mb-6">
+            <p class="mb-2">
               <span class="fh2">Thank You!</span>
-              <span class="tg-mobile-body text-on-background"
+              <span class="tg-body-mobile text-on-background"
                 >PMU successfuly submitted.</span
               >
             </p>
 
             <router-link
-              class="tg-mobile-body tg-text-brand3"
+              class="tg-body-mobile tg-text-brand3 underline"
               :to="{ name: 'Home' }"
               >Back to Home</router-link
             >

--- a/src/views/PmuSignFlow.vue
+++ b/src/views/PmuSignFlow.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <!-- NOTE: these files can affect other pages, so keeping them in component template, makes the isolated -->
     <link
       rel="stylesheet"
       href="https://unpkg.com/@ditdot-dev/vue-flow-form@1.1.0/dist/vue-flow-form.min.css"
@@ -24,12 +25,18 @@
             {{ errorMessage }}
           </ErrorFullScreen>
           <div v-else-if="isSubmitted">
-            <p>
+            <p class="mb-6">
               <span class="fh2">Thank You!</span>
               <span class="tg-mobile-body text-on-background"
                 >PMU successfuly submitted.</span
               >
             </p>
+
+            <router-link
+              class="tg-mobile-body tg-text-brand3"
+              :to="{ name: 'Home' }"
+              >Back to Home</router-link
+            >
           </div>
           <div v-else>
             <p>

--- a/src/views/PmuSignFlowMock.vue
+++ b/src/views/PmuSignFlowMock.vue
@@ -25,15 +25,15 @@
             {{ errorMessage }}
           </ErrorFullScreen>
           <div v-else-if="isSubmitted">
-            <p class="mb-6">
+            <p class="mb-2">
               <span class="fh2">Thank You!</span>
-              <span class="tg-mobile-body text-on-background"
+              <span class="tg-body-mobile text-on-background"
                 >PMU successfuly submitted.</span
               >
             </p>
 
             <router-link
-              class="tg-mobile-body tg-text-brand3"
+              class="tg-body-mobile tg-text-brand3 underline"
               :to="{ name: 'FormTemplateItemEdit' }"
               >Back to Form Template</router-link
             >

--- a/src/views/PmuSignFlowMock.vue
+++ b/src/views/PmuSignFlowMock.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <!-- NOTE: these files can affect other pages, so keeping them in component template, makes the isolated -->
     <link
       rel="stylesheet"
       href="https://unpkg.com/@ditdot-dev/vue-flow-form@1.1.0/dist/vue-flow-form.min.css"
@@ -24,12 +25,18 @@
             {{ errorMessage }}
           </ErrorFullScreen>
           <div v-else-if="isSubmitted">
-            <p>
+            <p class="mb-6">
               <span class="fh2">Thank You!</span>
               <span class="tg-mobile-body text-on-background"
                 >PMU successfuly submitted.</span
               >
             </p>
+
+            <router-link
+              class="tg-mobile-body tg-text-brand3"
+              :to="{ name: 'FormTemplateItemEdit' }"
+              >Back to Form Template</router-link
+            >
           </div>
           <div v-else>
             <p>
@@ -38,10 +45,10 @@
 
             <PmuFormFilledPreview
               v-if="isCompleted"
+              :isMock="true"
               title="Here is your PMU form:"
-              :clientId="clientId"
               :tenantSlug="tenantSlug"
-              :templateId="templateId"
+              :templateId="formId"
               :answers="answers"
             />
           </div>
@@ -55,15 +62,14 @@
 import FlowForm, { LanguageModel } from '@whynotearth/vue-flow-form';
 import { mapActions } from 'vuex';
 import { adaptApiQuestionsToModel, adaptAnswersToApi } from '@/services/pmu.js';
-import { get } from 'lodash-es';
 import PmuFormFilledPreview from '@/components/pmu/PmuFormFilledPreview.vue';
 import ErrorFullScreen from '@/components/ErrorFullScreen.vue';
 
 // https://github.com/ditdot-dev/vue-flow-form
 
 export default {
-  name: 'PmuSignFlowPreview',
-  props: ['tenantSlug', 'templateId'],
+  name: 'PmuSignFlowMock',
+  props: ['tenantSlug', 'formId'],
   components: {
     ErrorFullScreen,
     FlowForm,
@@ -89,11 +95,10 @@ export default {
     async init() {
       this.isCompleted = false;
       this.errorMessage = '';
-      const templateId = this.templateId;
       const template = await this.templateFetch({
         params: {
           tenantSlug: this.tenantSlug,
-          templateId
+          templateId: this.formId
         }
       });
       const questions = template.items;
@@ -103,36 +108,11 @@ export default {
       this.questions = adaptApiQuestionsToModel(questions);
       this.isReady = true;
     },
-    onSubmit(questionList) {
+    onSubmit() {
       // This method will only be called if you don't override the
       // completeButton slot.
 
-      const path = this.$router.resolve({
-        name: 'PmuFormDownload'
-      }).href;
-      const callbackUrl = `${window.location.origin}${path}`;
-      console.log('notificationCallBackUrl', callbackUrl);
-      const payload = adaptAnswersToApi(questionList, callbackUrl);
-
-      console.log('answers for api:', payload);
-      this.pmuSignSubmitAnswers({
-        params: {
-          clientId: this.clientId,
-          tenantSlug: this.tenantSlug,
-          templateId: this.templateId,
-          body: payload
-        }
-      })
-        .then(() => {
-          this.isSubmitted = true;
-        })
-        .catch(error => {
-          this.errorMessage = get(
-            error,
-            'response.data.message',
-            'Something went wrong, Answers not submitted.'
-          );
-        });
+      this.isSubmitted = true;
     },
     onComplete(completed, questionList) {
       this.answers = adaptAnswersToApi(questionList);

--- a/src/views/PmuSignFlowPreview.vue
+++ b/src/views/PmuSignFlowPreview.vue
@@ -1,0 +1,148 @@
+<template>
+  <div>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@ditdot-dev/vue-flow-form@1.1.0/dist/vue-flow-form.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@ditdot-dev/vue-flow-form@1.1.0/dist/vue-flow-form.theme-minimal.min.css"
+    />
+    <ErrorFullScreen :height="null" v-if="isReady && !(questions.length > 0)">
+      This form template has no questions.
+    </ErrorFullScreen>
+    <FlowForm
+      v-else-if="isReady"
+      v-on:submit="onSubmit"
+      v-on:complete="onComplete"
+      v-bind:questions="questions"
+      v-bind:language="language"
+    >
+      <template #complete>
+        <div class="section-wrap">
+          <ErrorFullScreen :height="null" v-if="errorMessage">
+            {{ errorMessage }}
+          </ErrorFullScreen>
+          <div v-else-if="isSubmitted">
+            <p>
+              <span class="fh2">Thank You!</span>
+              <span class="tg-mobile-body text-on-background"
+                >PMU successfuly submitted.</span
+              >
+            </p>
+          </div>
+          <div v-else>
+            <p>
+              <span class="fh2">Review and Sign</span>
+            </p>
+
+            <PmuFormFilledPreview
+              v-if="isCompleted"
+              title="Here is your PMU form:"
+              :clientId="clientId"
+              :tenantSlug="tenantSlug"
+              :templateId="templateId"
+              :answers="answers"
+            />
+          </div>
+        </div>
+      </template>
+    </FlowForm>
+  </div>
+</template>
+
+<script>
+import FlowForm, { LanguageModel } from '@whynotearth/vue-flow-form';
+import { mapActions } from 'vuex';
+import { adaptApiQuestionsToModel, adaptAnswersToApi } from '@/services/pmu.js';
+import { get } from 'lodash-es';
+import PmuFormFilledPreview from '@/components/pmu/PmuFormFilledPreview.vue';
+import ErrorFullScreen from '@/components/ErrorFullScreen.vue';
+
+// https://github.com/ditdot-dev/vue-flow-form
+
+export default {
+  name: 'PmuSignFlowPreview',
+  props: ['tenantSlug', 'templateId'],
+  components: {
+    ErrorFullScreen,
+    FlowForm,
+    PmuFormFilledPreview
+  },
+  created() {
+    this.init();
+  },
+  data() {
+    return {
+      isSubmitted: false,
+      isCompleted: false,
+      errorMessage: '',
+      isReady: false,
+      language: new LanguageModel({}),
+      answers: [],
+      questions: []
+    };
+  },
+  methods: {
+    ...mapActions('formTemplate', ['templateFetch']),
+    ...mapActions('client', ['pmuSignSubmitAnswers']),
+    async init() {
+      this.isCompleted = false;
+      this.errorMessage = '';
+      const templateId = this.templateId;
+      const template = await this.templateFetch({
+        params: {
+          tenantSlug: this.tenantSlug,
+          templateId
+        }
+      });
+      const questions = template.items;
+      this._adaptApiQuestionsToModel(questions);
+    },
+    _adaptApiQuestionsToModel(questions) {
+      this.questions = adaptApiQuestionsToModel(questions);
+      this.isReady = true;
+    },
+    onSubmit(questionList) {
+      // This method will only be called if you don't override the
+      // completeButton slot.
+
+      const path = this.$router.resolve({
+        name: 'PmuFormDownload'
+      }).href;
+      const callbackUrl = `${window.location.origin}${path}`;
+      console.log('notificationCallBackUrl', callbackUrl);
+      const payload = adaptAnswersToApi(questionList, callbackUrl);
+
+      console.log('answers for api:', payload);
+      this.pmuSignSubmitAnswers({
+        params: {
+          clientId: this.clientId,
+          tenantSlug: this.tenantSlug,
+          templateId: this.templateId,
+          body: payload
+        }
+      })
+        .then(() => {
+          this.isSubmitted = true;
+        })
+        .catch(error => {
+          this.errorMessage = get(
+            error,
+            'response.data.message',
+            'Something went wrong, Answers not submitted.'
+          );
+        });
+    },
+    onComplete(completed, questionList) {
+      this.answers = adaptAnswersToApi(questionList);
+      this.isCompleted = completed;
+    }
+  }
+};
+</script>
+
+<style>
+/* @import '~@whynotearth/vue-flow-form/dist/vue-flow-form.css';
+@import '~@whynotearth/vue-flow-form/dist/vue-flow-form.theme-minimal.css'; */
+</style>

--- a/src/views/PmuSignPreview.vue
+++ b/src/views/PmuSignPreview.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- todo: rename to PmuSign.vue -->
   <PageContentBoard>
     <!-- TODO rename questions to disclosures (or something meaningful and more general) everywhere -->
     <div class="max-w-4xl mx-auto px-4 pt-4">

--- a/src/views/PmuSignPreview.vue
+++ b/src/views/PmuSignPreview.vue
@@ -33,7 +33,6 @@
           <div>
             <PmuFormEmptyPreview
               title="Here is your pre-set PMU form:"
-              :clientId="clientId"
               :tenantSlug="tenantSlug"
               :templateId="templateId"
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3400,6 +3400,11 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+  integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
+
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,10 +1524,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@whynotearth/meredith-axios@^1.0.58":
-  version "1.0.58"
-  resolved "https://registry.yarnpkg.com/@whynotearth/meredith-axios/-/meredith-axios-1.0.58.tgz#24c4cd12d94f518a7d7c69fd5efc7bb8f652aad7"
-  integrity sha512-si+FOLMdOJ2ZB6i3NZmtJp+1jMJqADVPZOGDTJFLBgIqcNNl3XRBSFLV0hTUbphgDMYYgHMNYuEii5SkUQnBZQ==
+"@whynotearth/meredith-axios@^1.0.59":
+  version "1.0.59"
+  resolved "https://registry.yarnpkg.com/@whynotearth/meredith-axios/-/meredith-axios-1.0.59.tgz#1e8afd4e1d323c7710ae8f918c8ccc7d431bd950"
+  integrity sha512-TYydH2fUCB8lZzsLoxwVW+SRQVeUXbGYFy6Lt782XeMks79oZCb39cGDybBiJ7cce9GVewfs8iEVM1wLSlRYBA==
   dependencies:
     swagger-axios-codegen "^0.10.3"
 


### PR DESCRIPTION
# Issue Being Addressed

#370 

# Type of PR

[ ] Bug Fix
[ ] Refactor
[x] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For New Features:** What feature are we adding? Explain your technical approach to doing this.  

- Add preview modal and mock question flow in form-template (for previewing)  
- Add "Back to Home" to the last step of real question flow.


# How to Test/Reproduce

Go to form templates, create/select a form-template, click on preview,   
download the pdf file and click on preview button and check the question flow.  
Successful sign message is fake, and we don't submit anything.

# Screenshots/casts

![localhost_8080_tenant_elvis-butler-162_form-templates_item_83_edit_refresh=1](https://user-images.githubusercontent.com/510242/95484456-5aa1ca00-099d-11eb-9b5f-37796400866b.png)


# Additional Context

- Share button needs a fix. #407 