### PR TITLE
407 Fix file sharing in form-templates

### DIFF
--- a/src/components/formTemplate/FormTemplatePreviewModal.vue
+++ b/src/components/formTemplate/FormTemplatePreviewModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="h-vh100 bg-black bg-opacity-high z-50 fixed w-screen top-0 left-0 flex justify-center items-center"
+    class="h-vh100 bg-black z-50 fixed w-screen top-0 left-0 flex justify-center items-center"
   >
     <div
       class="flex flex-col items-center text-left w-full h-full relative"
@@ -27,9 +27,11 @@
       <!-- caption -->
       <div
         @click.stop=""
-        class="w-full content-gradient pb-14 absolute bottom-0"
+        class="w-full content-gradient pb-16 absolute bottom-0"
       >
-        <div class="py-10 px-4 text-on-background-image text-opacity-high">
+        <div
+          class="pt-10 pb-14 px-4 text-on-background-image text-opacity-high"
+        >
           <h1 class="tg-body-mobile mb-2">
             {{ currentTemplateGet.name }}
           </h1>
@@ -39,41 +41,42 @@
 
       <!-- bottom toolbar -->
       <div
-        class="flex justify-end w-full z-20"
+        class="flex flex-col justify-center w-full z-20 relative"
         @click.stop=""
-        :class="[isFileShareApiSupported && 'has-2-buttons']"
       >
-        <div class="flex flex-col justify-center w-full">
-          <div class="cta-wrapper">
-            <Button
-              title="Preview"
-              class="uppercase"
-              background="bg-primary"
-              textColor="text-on-primary"
-              @clicked="previewFlow"
-            />
-          </div>
+        <div
+          class="cta-wrapper absolute bottom-0 w-full flex items-center h-full"
+        >
+          <Button
+            title="Preview"
+            class="uppercase"
+            background="bg-primary"
+            textColor="text-on-primary"
+            @clicked="previewFlow"
+          />
         </div>
 
-        <!-- share -->
-        <a
-          v-if="isFileShareApiSupported"
-          @click.stop="onClickShare"
-          class="cursor-pointer p-4"
-          title="Share"
-        >
-          <ShareIcon class="text-white w-6 h-6" />
-        </a>
+        <div class="w-full flex justify-end relative z-10">
+          <!-- share -->
+          <a
+            v-if="isFileShareApiSupported"
+            @click.stop="onClickShare"
+            class="cursor-pointer p-4"
+            title="Share"
+          >
+            <ShareIcon class="text-white w-6 h-6" />
+          </a>
 
-        <!-- download -->
-        <a
-          @click.stop="onClickDownload"
-          class="cursor-pointer p-4"
-          :class="[loadingPdf ? 'pointer-events-none' : '']"
-          title="Download"
-        >
-          <DownloadIcon class="text-white w-6 h-6" />
-        </a>
+          <!-- download -->
+          <a
+            @click.stop="onClickDownload"
+            class="cursor-pointer p-4"
+            :class="[loadingPdf ? 'pointer-events-none' : '']"
+            title="Download"
+          >
+            <DownloadIcon class="text-white w-6 h-6" />
+          </a>
+        </div>
       </div>
     </div>
   </div>
@@ -181,9 +184,6 @@ export default {
   background: linear-gradient(180deg, transparent 0%, #000000 93.85%);
 }
 .cta-wrapper {
-  transform: translateY(-50%) translateX(28px);
-}
-.has-2-buttons .cta-wrapper {
-  transform: translateY(-50%) translateX(56px);
+  transform: translateY(-100%);
 }
 </style>

--- a/src/components/uploader/ImagePreviewModal.vue
+++ b/src/components/uploader/ImagePreviewModal.vue
@@ -60,7 +60,12 @@ import Close from '@/assets/icons/close.svg';
 import DeleteIcon from '@/assets/icons/delete.svg';
 import DownloadIcon from '@/assets/icons/download.svg';
 import ShareIcon from '@/assets/icons/share.svg';
-import { transformCloudinaryUrl, urlToFile, share } from '@/helpers.js';
+import {
+  transformCloudinaryUrl,
+  urlToFile,
+  share,
+  isShareApiSupported
+} from '@/helpers.js';
 import noPageScrollbarMixin from '@/utils/noPageScrollbarMixin.js';
 
 export default {
@@ -68,11 +73,9 @@ export default {
   mixins: [noPageScrollbarMixin],
   props: ['file'],
   components: { Close, DeleteIcon, DownloadIcon, ShareIcon },
-  computed: {
-    isShareApiSupported() {
-      return !!window.navigator.share;
-    }
-  },
+  data: () => ({
+    isShareApiSupported
+  }),
   methods: {
     transformCloudinaryUrl,
     urlToFile,

--- a/src/components/uploader/VideoPreviewModal.vue
+++ b/src/components/uploader/VideoPreviewModal.vue
@@ -55,7 +55,12 @@ import Close from '@/assets/icons/close.svg';
 import DeleteIcon from '@/assets/icons/delete.svg';
 import DownloadIcon from '@/assets/icons/download.svg';
 import ShareIcon from '@/assets/icons/share.svg';
-import { transformCloudinaryUrl, urlToFile, share } from '@/helpers.js';
+import {
+  transformCloudinaryUrl,
+  urlToFile,
+  share,
+  isShareApiSupported
+} from '@/helpers.js';
 import noPageScrollbarMixin from '@/utils/noPageScrollbarMixin.js';
 
 export default {
@@ -63,11 +68,9 @@ export default {
   mixins: [noPageScrollbarMixin],
   props: ['file'],
   components: { Close, DeleteIcon, DownloadIcon, ShareIcon },
-  computed: {
-    isShareApiSupported() {
-      return !!window.navigator.share;
-    }
-  },
+  data: () => ({
+    isShareApiSupported
+  }),
   methods: {
     transformCloudinaryUrl,
     urlToFile,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -151,11 +151,12 @@ export function urlToFile(jsonfile) {
 
 // https://stackoverflow.com/a/38935990
 function dataUrltoFile(dataurl, filename) {
-  var arr = dataurl.split(','),
-    mime = arr[0].match(/:(.*?);/)[1],
-    bstr = atob(arr[1]),
-    n = bstr.length,
-    u8arr = new Uint8Array(n);
+  const arr = dataurl.split(',');
+  console.log(arr);
+  const mime = arr[0].match(/:(.*?);/)[1];
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
 
   while (n--) {
     u8arr[n] = bstr.charCodeAt(n);
@@ -164,9 +165,9 @@ function dataUrltoFile(dataurl, filename) {
   return new File([u8arr], filename, { type: mime });
 }
 
-export function isShareApiSupported() {
-  return !!window.navigator.share;
-}
+// NOTE: this will return false on non-https addresses
+export const isShareApiSupported = !!window.navigator.share;
+export const isFileShareApiSupported = !!window.navigator.canShare;
 
 // no old share
 export function shareDataUrl({ data, filename }) {
@@ -178,8 +179,7 @@ export function shareDataUrl({ data, filename }) {
 
 // @input jsonfile: {url}
 export function share(jsonfile) {
-  const isFileSharingSupported = !!navigator.canShare;
-  if (!isFileSharingSupported) {
+  if (!isFileShareApiSupported) {
     _shareOld(jsonfile);
     return;
   }


### PR DESCRIPTION
# Issue Being Addressed

#407 (edited wrong mention to 417)

# Type of PR

[x] Bug Fix
[ ] Refactor
[ ] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?

- Sharing PDF file in form-template -> preview
- Preview button was not centered and was overlapped with share button.

# How to Test/Reproduce

Open a form template on an iOS/Android device and click preview.  
If your OS supports Web Share API - level 2, you should see a share button at the bottom of the page.

# Screenshots/casts

![localhost_8080_tenant_mort-174_form-templates_item_132_edit_refresh=1(iPhone 6_7_8)](https://user-images.githubusercontent.com/510242/95903128-9b854e80-0da2-11eb-923b-a8e5f77fbee3.png)
